### PR TITLE
change return type of GetPackageJSON to const pointer (for efficiency)

### DIFF
--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -75,7 +75,7 @@ void BindingData::Deserialize(v8::Local<v8::Context> context,
   CHECK_NOT_NULL(binding);
 }
 
-Local<Array> BindingData::PackageConfig::Serialize(Realm* realm) {
+Local<Array> BindingData::PackageConfig::Serialize(Realm* realm) const {
   auto has_manifest = !realm->env()->options()->experimental_policy.empty();
   auto isolate = realm->isolate();
   const auto ToString = [isolate](std::string_view input) -> Local<Primitive> {
@@ -95,19 +95,19 @@ Local<Array> BindingData::PackageConfig::Serialize(Realm* realm) {
   return Array::New(isolate, values, 7);
 }
 
-std::optional<BindingData::PackageConfig> BindingData::GetPackageJSON(
+const BindingData::PackageConfig* BindingData::GetPackageJSON(
     Realm* realm, const std::string& path, ErrorContext* error_context) {
   auto binding_data = realm->GetBindingData<BindingData>();
 
   auto cache_entry = binding_data->package_configs_.find(path);
   if (cache_entry != binding_data->package_configs_.end()) {
-    return cache_entry->second;
+    return &cache_entry->second;
   }
 
   std::string input;
   // No need to exclude BOM since simdjson will skip it.
   if (ReadFileSync(&input, path.c_str()) < 0) {
-    return std::nullopt;
+    return nullptr;
   }
 
   simdjson::ondemand::document document;
@@ -135,7 +135,7 @@ std::optional<BindingData::PackageConfig> BindingData::GetPackageJSON(
           realm->isolate(), "Invalid package config %s.", path.data());
     }
 
-    return std::nullopt;
+    return nullptr;
   };
 
   if (error || document.get_object().get(main_object)) {
@@ -148,7 +148,6 @@ std::optional<BindingData::PackageConfig> BindingData::GetPackageJSON(
   simdjson::ondemand::json_type field_type;
   PackageConfig package_config{};
   package_config.file_path = path;
-  package_config.raw_json = std::move(input);
 
   for (auto field : main_object) {
     // Throw error if getting key or value fails.
@@ -221,10 +220,14 @@ std::optional<BindingData::PackageConfig> BindingData::GetPackageJSON(
       }
     }
   }
+  // std::move(input) should only be used after we are sure that
+  // the input is no longer used by the JSON parser.
+  package_config.raw_json = std::move(input);
+  // package_config could be quite large, so we should move it instead of
+  // copying it.
+  auto cached = binding_data->package_configs_.insert({path, std::move(package_config)});
 
-  binding_data->package_configs_.insert({path, package_config});
-
-  return package_config;
+  return &cached.first->second;
 }
 
 void BindingData::ReadPackageJSON(const FunctionCallbackInfo<Value>& args) {
@@ -256,7 +259,7 @@ void BindingData::ReadPackageJSON(const FunctionCallbackInfo<Value>& args) {
 
   auto package_json =
       GetPackageJSON(realm, path.ToString(), is_esm ? &error_context : nullptr);
-  if (!package_json.has_value()) {
+  if (package_json == nullptr) {
     return;
   }
 
@@ -300,7 +303,7 @@ void BindingData::GetNearestParentPackageJSON(
 
     auto package_json = GetPackageJSON(
         realm, std::string(check_path) + kPathSeparator, nullptr);
-    if (package_json.has_value()) {
+    if (package_json != nullptr) {
       args.GetReturnValue().Set(package_json->Serialize(realm));
       return;
     }
@@ -350,7 +353,7 @@ void BindingData::GetNearestParentPackageJSONType(
     // GetPackageJSON will handle caching
     auto package_json =
         GetPackageJSON(realm, check_path_with_sep + "package.json");
-    if (package_json.has_value()) {
+    if (package_json != nullptr) {
       Local<Value> values[3] = {
           ToV8Value(realm->context(), package_json->type).ToLocalChecked(),
           ToV8Value(realm->context(), check_path_with_sep + "package.json")
@@ -398,7 +401,7 @@ void BindingData::GetPackageScopeConfig(
     CHECK(file_url);
     error_context.specifier = resolved.ToString();
     auto package_json = GetPackageJSON(realm, *file_url, &error_context);
-    if (package_json.has_value()) {
+    if (package_json != nullptr) {
       return args.GetReturnValue().Set(package_json->Serialize(realm));
     }
 

--- a/src/node_modules.h
+++ b/src/node_modules.h
@@ -34,7 +34,7 @@ class BindingData : public SnapshotableObject {
     std::optional<std::string> imports;
     std::string raw_json;
 
-    v8::Local<v8::Array> Serialize(Realm* realm);
+    v8::Local<v8::Array> Serialize(Realm* realm) const;
   };
 
   struct ErrorContext {
@@ -72,8 +72,8 @@ class BindingData : public SnapshotableObject {
  private:
   std::unordered_map<std::string, PackageConfig> package_configs_;
   simdjson::ondemand::parser json_parser;
-
-  static std::optional<PackageConfig> GetPackageJSON(
+  // returns null on error
+  static const PackageConfig* GetPackageJSON(
       Realm* realm,
       const std::string& path,
       ErrorContext* error_context = nullptr);


### PR DESCRIPTION
This PR is from a new branch to package-json-cache. It most just changes the return value GetPackageJSON so that you only hold one instance of PackageConfig (we no longer copy). This is the first step in a series of optimization we might apply, but I want to start with something simple (for ease of review).