### PR TITLE
replace std::string by std::string_view in PackageConfig

### DIFF
--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -104,16 +104,17 @@ const BindingData::PackageConfig* BindingData::GetPackageJSON(
     return &cache_entry->second;
   }
 
-  std::string input;
+  PackageConfig package_config{};
+  package_config.file_path = path;
   // No need to exclude BOM since simdjson will skip it.
-  if (ReadFileSync(&input, path.c_str()) < 0) {
+  if (ReadFileSync(&package_config.raw_json, package_config.file_path.c_str()) < 0) {
     return nullptr;
   }
 
   simdjson::ondemand::document document;
   simdjson::ondemand::object main_object;
   simdjson::error_code error =
-      binding_data->json_parser.iterate(input).get(document);
+      binding_data->json_parser.iterate(package_config.raw_json).get(document);
 
   const auto throw_invalid_package_config = [error_context, path, realm]() {
     if (error_context == nullptr) {
@@ -146,8 +147,6 @@ const BindingData::PackageConfig* BindingData::GetPackageJSON(
   simdjson::ondemand::value value;
   std::string_view field_value;
   simdjson::ondemand::json_type field_type;
-  PackageConfig package_config{};
-  package_config.file_path = path;
 
   for (auto field : main_object) {
     // Throw error if getting key or value fails.
@@ -175,7 +174,7 @@ const BindingData::PackageConfig* BindingData::GetPackageJSON(
           if (value.raw_json().get(field_value)) {
             return throw_invalid_package_config();
           }
-          package_config.exports = std::string(field_value);
+          package_config.exports = field_value;
           break;
         }
         case simdjson::ondemand::json_type::string: {
@@ -197,7 +196,7 @@ const BindingData::PackageConfig* BindingData::GetPackageJSON(
           if (value.raw_json().get(field_value)) {
             return throw_invalid_package_config();
           }
-          package_config.imports = std::string(field_value);
+          package_config.imports = field_value;
           break;
         }
         case simdjson::ondemand::json_type::string: {
@@ -216,13 +215,10 @@ const BindingData::PackageConfig* BindingData::GetPackageJSON(
       // Only update type if it is "commonjs" or "module"
       // The default value is "none" for backward compatibility.
       if (field_value == "commonjs" || field_value == "module") {
-        package_config.type = std::string(field_value);
+        package_config.type = field_value;
       }
     }
   }
-  // std::move(input) should only be used after we are sure that
-  // the input is no longer used by the JSON parser.
-  package_config.raw_json = std::move(input);
   // package_config could be quite large, so we should move it instead of
   // copying it.
   auto cached = binding_data->package_configs_.insert({path, std::move(package_config)});
@@ -358,7 +354,7 @@ void BindingData::GetNearestParentPackageJSONType(
           ToV8Value(realm->context(), package_json->type).ToLocalChecked(),
           ToV8Value(realm->context(), check_path_with_sep + "package.json")
               .ToLocalChecked(),
-          ToV8Value(realm->context(), package_json->raw_json).ToLocalChecked()};
+          ToV8Value(realm->context(), package_json->GetRawJSON()).ToLocalChecked()};
       args.GetReturnValue().Set(Array::New(realm->isolate(), values, 3));
       return;
     }

--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -107,7 +107,8 @@ const BindingData::PackageConfig* BindingData::GetPackageJSON(
   PackageConfig package_config{};
   package_config.file_path = path;
   // No need to exclude BOM since simdjson will skip it.
-  if (ReadFileSync(&package_config.raw_json, package_config.file_path.c_str()) < 0) {
+  if (ReadFileSync(&package_config.raw_json,
+        package_config.file_path.c_str()) < 0) {
     return nullptr;
   }
 
@@ -221,7 +222,8 @@ const BindingData::PackageConfig* BindingData::GetPackageJSON(
   }
   // package_config could be quite large, so we should move it instead of
   // copying it.
-  auto cached = binding_data->package_configs_.insert({path, std::move(package_config)});
+  auto cached = binding_data
+    ->package_configs_.insert({path, std::move(package_config)});
 
   return &cached.first->second;
 }
@@ -354,7 +356,8 @@ void BindingData::GetNearestParentPackageJSONType(
           ToV8Value(realm->context(), package_json->type).ToLocalChecked(),
           ToV8Value(realm->context(), check_path_with_sep + "package.json")
               .ToLocalChecked(),
-          ToV8Value(realm->context(), package_json->GetRawJSON()).ToLocalChecked()};
+          ToV8Value(realm->context(),
+              package_json->GetRawJSON()).ToLocalChecked()};
       args.GetReturnValue().Set(Array::New(realm->isolate(), values, 3));
       return;
     }

--- a/src/node_modules.h
+++ b/src/node_modules.h
@@ -37,7 +37,7 @@ class BindingData : public SnapshotableObject {
 
     v8::Local<v8::Array> Serialize(Realm* realm) const;
 
-    private:
+     private:
       // The std::string_view instances in this struct point to this string.
       // Modifying the string will invalidate the std::string_view instances.
       std::string raw_json;

--- a/src/node_modules.h
+++ b/src/node_modules.h
@@ -27,14 +27,21 @@ class BindingData : public SnapshotableObject {
 
   struct PackageConfig {
     std::string file_path;
-    std::optional<std::string> name;
-    std::optional<std::string> main;
+    std::optional<std::string_view> name;
+    std::optional<std::string_view> main;
     std::string type = "none";
-    std::optional<std::string> exports;
-    std::optional<std::string> imports;
-    std::string raw_json;
+    std::optional<std::string_view> exports;
+    std::optional<std::string_view> imports;
+
+    std::string_view GetRawJSON() const { return raw_json; }
 
     v8::Local<v8::Array> Serialize(Realm* realm) const;
+
+    private:
+      // The std::string_view instances in this struct point to this string.
+      // Modifying the string will invalidate the std::string_view instances.
+      std::string raw_json;
+      friend class BindingData;
   };
 
   struct ErrorContext {


### PR DESCRIPTION
This PR makes PackageConfig much smaller by using the fact that we are holding the original JSON as a string. We can then just use `std::string_view` instances safely for the rest of the components. This should improve the performance and reduce the memory usage.

Note: it is possible that this PR or the previous one might cause some breakage, but they should be essentially (conceptually) correct.