### PR TITLE
fix: use std::shared_ptr instead of std::unique_ptr for shared ressource, use operator[] instead of find_field

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1022,11 +1022,11 @@ int InitializeNodeWithArgs(std::vector<std::string>* argv,
       InitializeNodeWithArgsInternal(argv, exec_argv, errors, flags));
 }
 
-static std::unique_ptr<InitializationResultImpl>
+static std::shared_ptr<InitializationResultImpl>
 InitializeOncePerProcessInternal(const std::vector<std::string>& args,
                                  ProcessInitializationFlags::Flags flags =
                                      ProcessInitializationFlags::kNoFlags) {
-  auto result = std::make_unique<InitializationResultImpl>();
+  auto result = std::make_shared<InitializationResultImpl>();
   result->args_ = args;
 
   if (!(flags & ProcessInitializationFlags::kNoParseGlobalDebugVariables)) {
@@ -1068,7 +1068,7 @@ InitializeOncePerProcessInternal(const std::vector<std::string>& args,
     auto positional_args = task_runner::GetPositionalArgs(args);
     result->early_return_ = true;
     task_runner::RunTask(
-        &result, per_process::cli_options->run, positional_args);
+        result, per_process::cli_options->run, positional_args);
     return result;
   }
 
@@ -1231,7 +1231,7 @@ InitializeOncePerProcessInternal(const std::vector<std::string>& args,
   return result;
 }
 
-std::unique_ptr<InitializationResult> InitializeOncePerProcess(
+std::shared_ptr<InitializationResult> InitializeOncePerProcess(
     const std::vector<std::string>& args,
     ProcessInitializationFlags::Flags flags) {
   return InitializeOncePerProcessInternal(args, flags);
@@ -1437,7 +1437,7 @@ static ExitCode StartInternal(int argc, char** argv) {
   // Hack around with the argv pointer. Used for process.title = "blah".
   argv = uv_setup_args(argc, argv);
 
-  std::unique_ptr<InitializationResultImpl> result =
+  std::shared_ptr<InitializationResultImpl> result =
       InitializeOncePerProcessInternal(
           std::vector<std::string>(argv, argv + argc));
   for (const std::string& error : result->errors()) {

--- a/src/node.h
+++ b/src/node.h
@@ -349,7 +349,7 @@ NODE_DEPRECATED("Use InitializeOncePerProcess() instead",
 // including the arguments split into argv/exec_argv, a list of potential
 // errors encountered during initialization, and a potential suggested
 // exit code.
-NODE_EXTERN std::unique_ptr<InitializationResult> InitializeOncePerProcess(
+NODE_EXTERN std::shared_ptr<InitializationResult> InitializeOncePerProcess(
     const std::vector<std::string>& args,
     ProcessInitializationFlags::Flags flags =
         ProcessInitializationFlags::kNoFlags);
@@ -358,7 +358,7 @@ NODE_EXTERN std::unique_ptr<InitializationResult> InitializeOncePerProcess(
 NODE_EXTERN void TearDownOncePerProcess();
 // Convenience overload for specifying multiple flags without having
 // to worry about casts.
-inline std::unique_ptr<InitializationResult> InitializeOncePerProcess(
+inline std::shared_ptr<InitializationResult> InitializeOncePerProcess(
     const std::vector<std::string>& args,
     std::initializer_list<ProcessInitializationFlags::Flags> list) {
   uint64_t flags_accum = ProcessInitializationFlags::kNoFlags;

--- a/src/node_task_runner.h
+++ b/src/node_task_runner.h
@@ -16,7 +16,7 @@ namespace task_runner {
 
 class ProcessRunner {
  public:
-  ProcessRunner(std::unique_ptr<InitializationResultImpl>* result,
+  ProcessRunner(std::shared_ptr<InitializationResultImpl>& result,
                 std::string_view command_id,
                 const std::optional<std::string>& positional_args);
   void Run();
@@ -29,14 +29,14 @@ class ProcessRunner {
   uv_process_t process_{};
   uv_process_options_t options_{};
   uv_stdio_container_t child_stdio[3];
-  std::unique_ptr<InitializationResultImpl>* init_result;
+  std::shared_ptr<InitializationResultImpl> init_result;
   std::vector<std::string> command_args_{};
   std::vector<std::string> env_vars_{};
 
   void OnExit(int64_t exit_status, int term_signal);
 };
 
-void RunTask(std::unique_ptr<InitializationResultImpl>* result,
+void RunTask(std::shared_ptr<InitializationResultImpl>& result,
              std::string_view command_id,
              const std::optional<std::string>& positional_args);
 std::optional<std::string> GetPositionalArgs(

--- a/test/embedding/embedtest.cc
+++ b/test/embedding/embedtest.cc
@@ -30,7 +30,7 @@ static int RunNodeInstance(MultiIsolatePlatform* platform,
 int main(int argc, char** argv) {
   argv = uv_setup_args(argc, argv);
   std::vector<std::string> args(argv, argv + argc);
-  std::unique_ptr<node::InitializationResult> result =
+  std::shared_ptr<node::InitializationResult> result =
       node::InitializeOncePerProcess(
           args,
           {node::ProcessInitializationFlags::kNoInitializeV8,

--- a/tools/snapshot/node_mksnapshot.cc
+++ b/tools/snapshot/node_mksnapshot.cc
@@ -61,7 +61,7 @@ int BuildSnapshot(int argc, char* argv[]) {
     return 1;
   }
 
-  std::unique_ptr<node::InitializationResult> result =
+  std::shared_ptr<node::InitializationResult> result =
       node::InitializeOncePerProcess(
           std::vector<std::string>(argv, argv + argc),
           node::ProcessInitializationFlags::kGeneratePredictableSnapshot);


### PR DESCRIPTION
- In simdjson, we can use `find_field` or `find_field_unordered`. The `operator[]` is mapped to `find_field_unordered`. The `find_field` is fine, but it is used when you know the order of the keys, which is more appropriate for private JSON uses.
- I feel uneasy about having one `std:: unique_ptr` that gets passed as a pointer. To me, it suggests that `std:: shared_ptr` is more appropriate.
- The reset call on the object is fine.
- I have avoided some temporary `std::string` instances although it is probably not significant.
