### PR TITLE
fs: implement copyFileSync in C++

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -3682,11 +3682,7 @@ function copyFileSync(src, dest, mode) {
     const result = h.copyFileSync(src, dest, mode);
     if (result !== undefined) return;
   }
-  binding.copyFile(
-    getValidatedPath(src, 'src'),
-    getValidatedPath(dest, 'dest'),
-    mode,
-  );
+  binding.copyFileSync(src, dest, mode);
 }
 
 /**

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -46,6 +46,7 @@
 #include <errno.h>
 #include <cerrno>
 #include <cstdio>
+#include <cstring>
 #include <filesystem>
 
 #if defined(__MINGW32__) || defined(_MSC_VER)
@@ -78,6 +79,7 @@ using v8::LocalVector;
 using v8::Maybe;
 using v8::MaybeLocal;
 using v8::Nothing;
+using v8::NewStringType;
 using v8::Number;
 using v8::Object;
 using v8::ObjectTemplate;
@@ -2416,6 +2418,181 @@ static void OpenFileHandle(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
+// Matches lib/internal/url.js isURL(): duck-type WHATWG URL objects vs
+// legacy url.parse() results (which have `auth` and `path` properties).
+static bool IsUrlLike(Environment* env, Local<Value> value) {
+  if (!value->IsObject() || value->IsUint8Array()) {
+    return false;
+  }
+
+  Isolate* isolate = env->isolate();
+  Local<Context> context = env->context();
+  Local<Object> obj = value.As<Object>();
+
+  Local<Value> href;
+  if (!obj->Get(context, env->href_string()).ToLocal(&href)) {
+    return false;
+  }
+  if (!href->BooleanValue(isolate)) {
+    return false;
+  }
+
+  Local<Value> protocol;
+  if (!obj->Get(context, env->protocol_string()).ToLocal(&protocol)) {
+    return false;
+  }
+  if (!protocol->BooleanValue(isolate)) {
+    return false;
+  }
+
+  Local<Value> auth;
+  if (!obj->Get(context, FIXED_ONE_BYTE_STRING(isolate, "auth"))
+           .ToLocal(&auth)) {
+    return false;
+  }
+
+  Local<Value> path;
+  if (!obj->Get(context, env->path_string()).ToLocal(&path)) {
+    return false;
+  }
+
+  return auth->IsUndefined() && path->IsUndefined();
+}
+
+static bool ContainsNul(const BufferValue& path) {
+  return path.length() > 0 &&
+         std::memchr(path.out(), '\0', path.length()) != nullptr;
+}
+
+// C++ equivalent of getValidatedPath(value, propName): accepts string,
+// Uint8Array/Buffer, or WHATWG URL, rejects embedded NUL bytes, and converts
+// file: URLs to paths. Returns an empty MaybeLocal and throws on failure.
+static MaybeLocal<Value> GetValidatedPath(Environment* env,
+                                          Local<Value> input,
+                                          const char* prop_name) {
+  Isolate* isolate = env->isolate();
+
+  if (input->IsString() || input->IsUint8Array()) {
+    return input;
+  }
+
+  if (IsUrlLike(env, input)) {
+    Local<Context> context = env->context();
+    Local<Value> href;
+    if (!input.As<Object>()
+             ->Get(context, env->href_string())
+             .ToLocal(&href)) {
+      return MaybeLocal<Value>();
+    }
+
+    Utf8Value href_utf8(isolate, href);
+    auto parsed = ada::parse<ada::url_aggregator>(href_utf8.ToStringView());
+    if (!parsed) {
+      url::ThrowInvalidURL(env, href_utf8.ToStringView(), std::nullopt);
+      return MaybeLocal<Value>();
+    }
+
+    std::optional<std::string> file_path = url::FileURLToPath(env, *parsed);
+    if (!file_path.has_value()) {
+      return MaybeLocal<Value>();
+    }
+
+    if (file_path->find('\0') != std::string::npos) {
+      THROW_ERR_INVALID_ARG_VALUE(
+          env,
+          "The argument '%s' must be a string, Uint8Array, or URL "
+          "without null bytes. Received %s",
+          prop_name,
+          DetermineSpecificErrorType(env, input));
+      return MaybeLocal<Value>();
+    }
+
+    Local<String> path_string;
+    if (!String::NewFromUtf8(isolate,
+                             file_path->data(),
+                             NewStringType::kNormal,
+                             static_cast<int>(file_path->size()))
+             .ToLocal(&path_string)) {
+      return MaybeLocal<Value>();
+    }
+    return path_string;
+  }
+
+  if (isolate->HasPendingException()) {
+    return MaybeLocal<Value>();
+  }
+
+  THROW_ERR_INVALID_ARG_TYPE(
+      env,
+      "The \"%s\" argument must be of type string or an instance of "
+      "Buffer or URL. Received %s",
+      prop_name,
+      DetermineSpecificErrorType(env, input));
+  return MaybeLocal<Value>();
+}
+
+// Full C++ implementation of fs.copyFileSync(): path validation, mode
+// validation, permission checks, and the copy itself.
+static void CopyFileSync(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  Isolate* isolate = env->isolate();
+
+  CHECK_GE(args.Length(), 2);  // src, dest[, mode]
+
+  Local<Value> src_val;
+  if (!GetValidatedPath(env, args[0], "src").ToLocal(&src_val)) {
+    return;
+  }
+  Local<Value> dest_val;
+  if (!GetValidatedPath(env, args[1], "dest").ToLocal(&dest_val)) {
+    return;
+  }
+
+  BufferValue src(isolate, src_val);
+  CHECK_NOT_NULL(*src);
+  if (ContainsNul(src)) {
+    THROW_ERR_INVALID_ARG_VALUE(
+        env,
+        "The argument 'src' must be a string, Uint8Array, or URL "
+        "without null bytes. Received %s",
+        DetermineSpecificErrorType(env, args[0]));
+    return;
+  }
+
+  BufferValue dest(isolate, dest_val);
+  CHECK_NOT_NULL(*dest);
+  if (ContainsNul(dest)) {
+    THROW_ERR_INVALID_ARG_VALUE(
+        env,
+        "The argument 'dest' must be a string, Uint8Array, or URL "
+        "without null bytes. Received %s",
+        DetermineSpecificErrorType(env, args[1]));
+    return;
+  }
+
+  Local<Value> mode = args.Length() > 2 ? args[2] : Undefined(isolate);
+  int flags;
+  if (!GetValidFileMode(env, mode, UV_FS_COPYFILE).To(&flags)) {
+    return;
+  }
+
+  ToNamespacedPath(env, &src);
+  ToNamespacedPath(env, &dest);
+
+  THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kFileSystemRead, src.ToStringView());
+  THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env,
+      permission::PermissionScope::kFileSystemWrite,
+      dest.ToStringView());
+
+  FSReqWrapSync req_wrap_sync("copyfile", *src, *dest);
+  FS_SYNC_TRACE_BEGIN(copyfile);
+  SyncCallAndThrowOnError(
+      env, &req_wrap_sync, uv_fs_copyfile, *src, *dest, flags);
+  FS_SYNC_TRACE_END(copyfile);
+}
+
 static void CopyFile(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Isolate* isolate = env->isolate();
@@ -4229,6 +4406,7 @@ static void CreatePerIsolateProperties(IsolateData* isolate_data,
   SetMethod(isolate, target, "writeFileUtf8", WriteFileUtf8);
   SetMethod(isolate, target, "realpath", RealPath);
   SetMethod(isolate, target, "copyFile", CopyFile);
+  SetMethod(isolate, target, "copyFileSync", CopyFileSync);
 
   SetMethod(isolate, target, "chmod", Chmod);
   SetMethod(isolate, target, "fchmod", FChmod);
@@ -4357,6 +4535,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(WriteFileUtf8);
   registry->Register(RealPath);
   registry->Register(CopyFile);
+  registry->Register(CopyFileSync);
 
   registry->Register(CpSyncCheckPaths);
   registry->Register(CpSyncOverrideFile);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2492,6 +2492,13 @@ static MaybeLocal<Value> GetValidatedPath(Environment* env,
       return MaybeLocal<Value>();
     }
 
+    // Match lib/internal/url.js fileURLToPath(): non-file schemes throw
+    // ERR_INVALID_URL_SCHEME with the same message as JS (`file`, not `file:`).
+    if (parsed->type != ada::scheme::FILE) {
+      THROW_ERR_INVALID_URL_SCHEME(isolate, "The URL must be of scheme file");
+      return MaybeLocal<Value>();
+    }
+
     std::optional<std::string> file_path = url::FileURLToPath(env, *parsed);
     if (!file_path.has_value()) {
       return MaybeLocal<Value>();

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -688,7 +688,7 @@ std::optional<std::string> FileURLToPath(Environment* env,
   if (hostname.size() > 0) {
     THROW_ERR_INVALID_FILE_URL_HOST(
         env->isolate(),
-        "File URL host must be \"localhost\" or empty on ",
+        "File URL host must be \"localhost\" or empty on %s",
         std::string(per_process::metadata.platform));
     return std::nullopt;
   }

--- a/test/parallel/test-fs-copyfile.js
+++ b/test/parallel/test-fs-copyfile.js
@@ -10,6 +10,7 @@ const {
   UV_ENOENT,
   UV_EEXIST
 } = internalBinding('uv');
+const { pathToFileURL } = require('url');
 const src = fixtures.path('a.js');
 const dest = tmpdir.resolve('copyfile.out');
 const {
@@ -54,6 +55,17 @@ verify(src, dest);
 // Verify that files are overwritten with default flags.
 fs.copyFileSync(src, dest, 0);
 verify(src, dest);
+
+// Verify Buffer and file: URL paths.
+{
+  const destBuf = tmpdir.resolve('copyfile.buffer');
+  fs.copyFileSync(Buffer.from(src), Buffer.from(destBuf));
+  verify(src, destBuf);
+
+  const destUrl = tmpdir.resolve('copyfile.url');
+  fs.copyFileSync(pathToFileURL(src), pathToFileURL(destUrl));
+  verify(src, destUrl);
+}
 
 // Verify that UV_FS_COPYFILE_FICLONE can be used.
 fs.unlinkSync(dest);
@@ -140,6 +152,13 @@ assert.throws(() => {
       message: /dest/
     }
   );
+});
+
+assert.throws(() => {
+  fs.copyFileSync(new URL('http://example.com/a'), dest);
+}, {
+  code: 'ERR_INVALID_URL_SCHEME',
+  name: 'TypeError',
 });
 
 assert.throws(() => {

--- a/test/parallel/test-fs-copyfile.js
+++ b/test/parallel/test-fs-copyfile.js
@@ -65,6 +65,11 @@ verify(src, dest);
   const destUrl = tmpdir.resolve('copyfile.url');
   fs.copyFileSync(pathToFileURL(src), pathToFileURL(destUrl));
   verify(src, destUrl);
+
+  const destU8 = tmpdir.resolve('copyfile.uint8');
+  fs.copyFileSync(new Uint8Array(Buffer.from(src)),
+                  new Uint8Array(Buffer.from(destU8)));
+  verify(src, destU8);
 }
 
 // Verify that UV_FS_COPYFILE_FICLONE can be used.
@@ -159,7 +164,37 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_URL_SCHEME',
   name: 'TypeError',
+  message: 'The URL must be of scheme file',
 });
+
+if (common.isWindows) {
+  ['%2f', '%2F', '%5c', '%5C'].forEach((i) => {
+    assert.throws(
+      () => fs.copyFileSync(new URL(`file:///c:/tmp/${i}`), dest),
+      {
+        code: 'ERR_INVALID_FILE_URL_PATH',
+        name: 'TypeError',
+      }
+    );
+  });
+} else {
+  ['%2f', '%2F'].forEach((i) => {
+    assert.throws(
+      () => fs.copyFileSync(new URL(`file:///c:/tmp/${i}`), dest),
+      {
+        code: 'ERR_INVALID_FILE_URL_PATH',
+        name: 'TypeError',
+      }
+    );
+  });
+  assert.throws(
+    () => fs.copyFileSync(new URL('file://hostname/a/b/c'), dest),
+    {
+      code: 'ERR_INVALID_FILE_URL_HOST',
+      name: 'TypeError',
+    }
+  );
+}
 
 assert.throws(() => {
   fs.copyFileSync(src, dest, 'r');

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -75,6 +75,7 @@ declare namespace InternalFSBinding {
   function copyFile(src: StringOrBuffer, dest: StringOrBuffer, mode: number, req: FSReqCallback): void;
   function copyFile(src: StringOrBuffer, dest: StringOrBuffer, mode: number, req: undefined, ctx: FSSyncContext): void;
   function copyFile(src: StringOrBuffer, dest: StringOrBuffer, mode: number, usePromises: typeof kUsePromises): Promise<void>;
+  function copyFileSync(src: unknown, dest: unknown, mode?: unknown): void;
 
   function cpSyncCheckPaths(src: StringOrBuffer, dest: StringOrBuffer, dereference: boolean, recursive: boolean): void;
   function cpSyncOverrideFile(src: StringOrBuffer, dest: StringOrBuffer, mode: number, preserveTimestamps: boolean): void;
@@ -261,6 +262,7 @@ export interface FsBinding {
   chown: typeof InternalFSBinding.chown;
   close: typeof InternalFSBinding.close;
   copyFile: typeof InternalFSBinding.copyFile;
+  copyFileSync: typeof InternalFSBinding.copyFileSync;
   cpSyncCheckPaths: typeof InternalFSBinding.cpSyncCheckPaths;
   cpSyncOverrideFile: typeof InternalFSBinding.cpSyncOverrideFile;
   cpSyncCopyDir: typeof InternalFSBinding.cpSyncCopyDir;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Rewrite `fs.copyFileSync()` so the entire implementation lives in C++.

JavaScript now only does VFS dispatch. Everything else — path type checks (`string` / `Buffer` / `Uint8Array` / `URL`), file URL conversion, embedded-NUL rejection, mode validation, permission-model checks, and the copy — runs in a dedicated `binding.copyFileSync()` function.

The copy itself still uses `uv_fs_copyfile`, so flags (`COPYFILE_EXCL`, `COPYFILE_FICLONE`, `COPYFILE_FICLONE_FORCE`), mode/timestamp preservation, same-file handling, and UV error shapes (`syscall: 'copyfile'`, `path` / `dest`) stay identical.

Also fixes a crash in the C++ `FileURLToPath` helper: `ERR_INVALID_FILE_URL_HOST` used a format string without `%s`, which aborted when converting a file URL with a hostname (now reachable from `copyFileSync`).

## Why

`copyFileSync` was paying for two `getValidatedPath()` trips in JS on every call. Moving that work next to the existing C++ permission checks and `uv_fs_copyfile` removes that overhead without changing behavior.

## Testing

All of the following passed against `./out/Release/node`:

- `test/parallel/test-fs-copyfile.js` (Buffer, `Uint8Array`, `file:` URL, non-file URL, encoded slashes, file URL host)
- `test/parallel/test-fs-copyfile-respect-permissions.js`
- `test/parallel/test-fs-null-bytes.js`
- `test/parallel/test-fs-error-messages.js`
- `test/parallel/test-fs-whatwg-url.js`
- `test/parallel/test-url-fileurltopath.js`
- VFS: `test-vfs-fs-copyFileSync.js`, `test-vfs-copyfile-mode.js`, `test-vfs-mount-errors.js`, real/memory providers
- Permission model: `test-permission-fs-read.js`, `test-permission-fs-write.js`
- Other `copyFileSync` callers: `test-fs-lchown.js`, `test-fs-fsync.js`, `test-fs-open-flags.js`, `test-trace-events-fs-sync.js`, `test-require-symlink.js`

Compared C++ `copyFileSync` vs the old JS `getValidatedPath` + `binding.copyFile` path (`n=1e4`):

| case | vs old |
|---|---|
| valid copy | ~6% faster |
| missing src (ENOENT) | ~7% faster |
| invalid type | ~68% faster |
| file URL | ~1% faster |

Official `benchmark/fs/bench-copyFileSync.js` also ran (`type=valid` / `type=invalid`, `n=10000`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01243-0f41-77ce-b486-53693f21317c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01243-0f41-77ce-b486-53693f21317c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

