### PR TITLE
build: use build-ci for benchmark merge-commit rebuild

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -141,7 +141,7 @@ jobs:
             --arg devTools '[]' \
             --arg benchmarkTools '[]' \
             --run '
-                make -j4 V=1
+                make build-ci -j4 V=1
             '
 
       - name: Run benchmark


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The benchmark workflow’s merge-commit rebuild used `make -j4`, which skips configure. After `node.gyp` or generated sources change, that can leave the comparison binary unlinked against new files.

This switches that step to `make build-ci -j4 V=1`, matching the base-build job.

Standalone CI fix; not part of https://github.com/nodejs/node/pull/65273.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0117b-9d57-7f2c-aa35-2403c7eb1677?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0117b-9d57-7f2c-aa35-2403c7eb1677&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

