### PR TITLE
url: speed up URLPattern

### DIFF
--- a/src/node_url_pattern.cc
+++ b/src/node_url_pattern.cc
@@ -6,7 +6,10 @@
 #include "node_errors.h"
 #include "node_mem-inl.h"
 #include "path.h"
+#include "simdutf.h"
 #include "util-inl.h"
+
+#include <cstring>
 
 namespace node {
 using node::url_pattern::URLPatternRegexProvider;
@@ -64,7 +67,6 @@ using v8::Local;
 using v8::LocalVector;
 using v8::MaybeLocal;
 using v8::Name;
-using v8::NewStringType;
 using v8::Object;
 using v8::PropertyAttribute;
 using v8::ReadOnly;
@@ -73,25 +75,117 @@ using v8::Signature;
 using v8::String;
 using v8::Value;
 
+namespace {
+
+// String::ValueView holds DisallowGarbageCollection. Copy into a C++ buffer
+// and destroy the view before creating any V8 heap objects.
+void CopyV8StringToBuffer(Isolate* isolate,
+                          Local<String> str,
+                          MaybeStackBuffer<char>* buffer) {
+  if (str->Length() == 0) {
+    buffer->SetLength(0);
+    return;
+  }
+  {
+    String::ValueView view(isolate, str);
+    if (view.is_one_byte()) {
+      const auto* data = reinterpret_cast<const char*>(view.data8());
+      const size_t length = view.length();
+      if (simdutf::validate_ascii(data, length)) [[likely]] {
+        buffer->AllocateSufficientStorage(length);
+        memcpy(buffer->out(), data, length);
+        buffer->SetLength(length);
+        return;
+      }
+    }
+  }
+  Utf8Value utf8(isolate, str);
+  buffer->AllocateSufficientStorage(utf8.length());
+  if (utf8.length() != 0) {
+    memcpy(buffer->out(), *utf8, utf8.length());
+  }
+  buffer->SetLength(utf8.length());
+}
+
+std::string V8StringToStdString(Isolate* isolate, Local<String> str) {
+  if (str->Length() == 0) {
+    return std::string();
+  }
+  {
+    String::ValueView view(isolate, str);
+    if (view.is_one_byte()) {
+      const auto* data = reinterpret_cast<const char*>(view.data8());
+      const size_t length = view.length();
+      if (simdutf::validate_ascii(data, length)) [[likely]] {
+        return std::string(data, length);
+      }
+    }
+  }
+  Utf8Value utf8(isolate, str);
+  return utf8.ToString();
+}
+
+// ada::url_pattern_input holds a string_view, so input_buf/base_buf must
+// outlive the subsequent test/exec call.
+bool ExtractInputAndBaseURL(Environment* env,
+                            const FunctionCallbackInfo<Value>& args,
+                            ada::url_pattern_input* input,
+                            std::optional<std::string_view>* base_url,
+                            MaybeStackBuffer<char>* input_buf,
+                            MaybeStackBuffer<char>* base_buf) {
+  Isolate* isolate = env->isolate();
+  if (args.Length() == 0 || args[0]->IsNullOrUndefined()) {
+    *input = ada::url_pattern_init{};
+  } else if (args[0]->IsString()) {
+    CopyV8StringToBuffer(isolate, args[0].As<String>(), input_buf);
+    *input = input_buf->ToStringView();
+  } else if (args[0]->IsObject()) {
+    auto maybe_input =
+        URLPattern::URLPatternInit::FromJsObject(env, args[0].As<Object>());
+    if (!maybe_input.has_value()) {
+      return false;
+    }
+    *input = std::move(*maybe_input);
+  } else {
+    THROW_ERR_INVALID_ARG_TYPE(
+        env, "URLPattern input needs to be a string or an object");
+    return false;
+  }
+
+  if (args.Length() > 1 && !args[1]->IsUndefined()) {
+    if (args[1]->IsNull()) {
+      *base_url = std::string_view("null");
+    } else if (args[1]->IsString()) {
+      CopyV8StringToBuffer(isolate, args[1].As<String>(), base_buf);
+      *base_url = base_buf->ToStringView();
+    } else {
+      THROW_ERR_INVALID_ARG_TYPE(env, "baseURL must be a string");
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
 std::optional<URLPatternRegexProvider::regex_type>
 URLPatternRegexProvider::create_instance(std::string_view pattern,
                                          bool ignore_case) {
   auto isolate = Isolate::GetCurrent();
-  auto env = Environment::GetCurrent(isolate);
   int flags = RegExp::Flags::kUnicodeSets | RegExp::Flags::kDotAll;
   if (ignore_case) {
     flags |= static_cast<int>(RegExp::Flags::kIgnoreCase);
   }
 
-  Local<String> local_pattern;
-  if (!String::NewFromUtf8(
-           isolate, pattern.data(), NewStringType::kNormal, pattern.size())
-           .ToLocal(&local_pattern)) {
+  Local<Context> context = isolate->GetCurrentContext();
+  Local<Value> pattern_value;
+  if (!ToV8Value(context, pattern, isolate).ToLocal(&pattern_value)) {
     return std::nullopt;
   }
   Local<RegExp> regexp;
-  if (!RegExp::New(
-           env->context(), local_pattern, static_cast<RegExp::Flags>(flags))
+  if (!RegExp::New(context,
+                   pattern_value.As<String>(),
+                   static_cast<RegExp::Flags>(flags))
            .ToLocal(&regexp)) {
     return std::nullopt;
   }
@@ -101,16 +195,14 @@ URLPatternRegexProvider::create_instance(std::string_view pattern,
 bool URLPatternRegexProvider::regex_match(std::string_view input,
                                           const regex_type& pattern) {
   auto isolate = Isolate::GetCurrent();
-  auto env = Environment::GetCurrent(isolate);
-  Local<String> local_input;
-  if (!String::NewFromUtf8(
-           isolate, input.data(), NewStringType::kNormal, input.size())
-           .ToLocal(&local_input)) {
+  Local<Context> context = isolate->GetCurrentContext();
+  Local<Value> input_value;
+  if (!ToV8Value(context, input, isolate).ToLocal(&input_value)) {
     return false;
   }
   Local<Object> result_object;
   if (!pattern.Get(isolate)
-           ->Exec(env->context(), local_input)
+           ->Exec(context, input_value.As<String>())
            .ToLocal(&result_object)) {
     return false;
   }
@@ -122,16 +214,14 @@ std::optional<std::vector<std::optional<std::string>>>
 URLPatternRegexProvider::regex_search(std::string_view input,
                                       const regex_type& global_pattern) {
   auto isolate = Isolate::GetCurrent();
-  auto env = Environment::GetCurrent(isolate);
-  Local<String> local_input;
-  if (!String::NewFromUtf8(
-           isolate, input.data(), NewStringType::kNormal, input.size())
-           .ToLocal(&local_input)) {
+  Local<Context> context = isolate->GetCurrentContext();
+  Local<Value> input_value;
+  if (!ToV8Value(context, input, isolate).ToLocal(&input_value)) {
     return std::nullopt;
   }
   Local<Object> exec_result_object;
   auto pattern = global_pattern.Get(isolate);
-  if (!pattern->Exec(env->context(), local_input)
+  if (!pattern->Exec(context, input_value.As<String>())
            .ToLocal(&exec_result_object) ||
       exec_result_object->IsNull()) {
     return std::nullopt;
@@ -143,7 +233,7 @@ URLPatternRegexProvider::regex_search(std::string_view input,
   result.reserve(len);
   for (size_t i = 1; i < len; i++) {
     Local<Value> entry;
-    if (!exec_result->Get(env->context(), i).ToLocal(&entry)) {
+    if (!exec_result->Get(context, i).ToLocal(&entry)) {
       return std::nullopt;
     }
 
@@ -153,8 +243,7 @@ URLPatternRegexProvider::regex_search(std::string_view input,
     if (entry->IsUndefined()) {
       result.emplace_back(std::nullopt);
     } else if (entry->IsString()) {
-      Utf8Value utf8_entry(isolate, entry.As<String>());
-      result.emplace_back(utf8_entry.ToString());
+      result.emplace_back(V8StringToStdString(isolate, entry.As<String>()));
     }
   }
   return result;
@@ -193,9 +282,12 @@ void URLPattern::New(const FunctionCallbackInfo<Value>& args) {
   }
 
   std::optional<ada::url_pattern_init> init{};
-  std::optional<std::string> input{};
-  std::optional<std::string> base_url{};
+  MaybeStackBuffer<char> input_buf;
+  MaybeStackBuffer<char> base_url_buf;
+  std::optional<std::string_view> input{};
+  std::optional<std::string_view> base_url{};
   std::optional<ada::url_pattern_options> options{};
+  Isolate* isolate = env->isolate();
 
   // Following patterns are supported:
   // - new URLPattern(input)
@@ -207,9 +299,8 @@ void URLPattern::New(const FunctionCallbackInfo<Value>& args) {
   if (args[0]->IsNullOrUndefined()) {
     init = ada::url_pattern_init{};
   } else if (args[0]->IsString()) {
-    BufferValue input_buffer(env->isolate(), args[0]);
-    CHECK_NOT_NULL(*input_buffer);
-    input = input_buffer.ToString();
+    CopyV8StringToBuffer(isolate, args[0].As<String>(), &input_buf);
+    input = input_buf.ToStringView();
   } else if (args[0]->IsObject()) {
     init = URLPatternInit::FromJsObject(env, args[0].As<Object>());
     // If init does not have a value here, the implication is that an
@@ -230,13 +321,12 @@ void URLPattern::New(const FunctionCallbackInfo<Value>& args) {
     // USVString ("null"/"undefined"), which will be rejected as invalid
     // URLs by ada downstream.
     if (args[1]->IsString()) {
-      BufferValue base_url_buffer(env->isolate(), args[1]);
-      CHECK_NOT_NULL(*base_url_buffer);
-      base_url = base_url_buffer.ToString();
+      CopyV8StringToBuffer(isolate, args[1].As<String>(), &base_url_buf);
+      base_url = base_url_buf.ToStringView();
     } else if (args[1]->IsNull()) {
-      base_url = std::string("null");
+      base_url = std::string_view("null");
     } else if (args[1]->IsUndefined()) {
-      base_url = std::string("undefined");
+      base_url = std::string_view("undefined");
     } else {
       THROW_ERR_INVALID_ARG_TYPE(env, "second argument must be a string");
       return;
@@ -257,9 +347,8 @@ void URLPattern::New(const FunctionCallbackInfo<Value>& args) {
     // Overload resolution: string is overload 1 (baseURL),
     // otherwise overload 2 (options).
     if (args[1]->IsString()) {
-      BufferValue base_url_buffer(env->isolate(), args[1]);
-      CHECK_NOT_NULL(*base_url_buffer);
-      base_url = base_url_buffer.ToString();
+      CopyV8StringToBuffer(isolate, args[1].As<String>(), &base_url_buf);
+      base_url = base_url_buf.ToStringView();
     } else if (args[1]->IsNullOrUndefined()) {
       // Overload 2, options uses default.
     } else if (args[1]->IsObject()) {
@@ -276,19 +365,16 @@ void URLPattern::New(const FunctionCallbackInfo<Value>& args) {
   // Either url_pattern_init or input as a string must be provided.
   CHECK_IMPLIES(init.has_value(), !input.has_value());
 
-  std::string_view base_url_view{};
-  if (base_url) base_url_view = {base_url->data(), base_url->size()};
-
   ada::url_pattern_input arg0;
   if (init.has_value()) {
     arg0 = std::move(*init);
   } else {
-    arg0 = std::move(*input);
+    arg0 = *input;
   }
 
   auto url_pattern = parse_url_pattern<URLPatternRegexProvider>(
       std::move(arg0),
-      base_url ? &base_url_view : nullptr,
+      base_url ? &*base_url : nullptr,
       options.has_value() ? &options.value() : nullptr);
 
   if (!url_pattern) {
@@ -358,7 +444,9 @@ MaybeLocal<Value> URLPattern::URLPatternInit::ToJsObject(
 std::optional<ada::url_pattern_init> URLPattern::URLPatternInit::FromJsObject(
     Environment* env, Local<Object> obj) {
   ada::url_pattern_init init{};
-  Local<String> components[] = {
+  Isolate* isolate = env->isolate();
+  Local<Context> context = env->context();
+  Local<String> names[] = {
       env->protocol_string(),
       env->username_string(),
       env->password_string(),
@@ -369,40 +457,30 @@ std::optional<ada::url_pattern_init> URLPattern::URLPatternInit::FromJsObject(
       env->hash_string(),
       env->base_url_string(),
   };
-  auto isolate = env->isolate();
-  const auto set_parameter = [&](std::string_view key, std::string_view value) {
-    if (key == "protocol") {
-      init.protocol = std::string(value);
-    } else if (key == "username") {
-      init.username = std::string(value);
-    } else if (key == "password") {
-      init.password = std::string(value);
-    } else if (key == "hostname") {
-      init.hostname = std::string(value);
-    } else if (key == "port") {
-      init.port = std::string(value);
-    } else if (key == "pathname") {
-      init.pathname = std::string(value);
-    } else if (key == "search") {
-      init.search = std::string(value);
-    } else if (key == "hash") {
-      init.hash = std::string(value);
-    } else if (key == "baseURL") {
-      init.base_url = std::string(value);
-    }
+  std::optional<std::string>* fields[] = {
+      &init.protocol,
+      &init.username,
+      &init.password,
+      &init.hostname,
+      &init.port,
+      &init.pathname,
+      &init.search,
+      &init.hash,
+      &init.base_url,
   };
-  Local<Value> value;
-  for (const auto& component : components) {
-    Utf8Value key(isolate, component);
-    if (obj->Get(env->context(), component).ToLocal(&value)) {
-      if (value->IsString()) {
-        Utf8Value utf8_value(isolate, value);
-        set_parameter(key.ToStringView(), utf8_value.ToStringView());
-      }
-    } else {
+  static_assert(arraysize(names) == arraysize(fields));
+
+  for (size_t i = 0; i < arraysize(names); i++) {
+    Local<Value> value;
+    if (!obj->Get(context, names[i]).ToLocal(&value)) {
       // If ToLocal failed then we assume an error occurred,
       // bail out early to propagate the error.
       return std::nullopt;
+    }
+    // Non-string values are ignored. This matches the previous binding
+    // and avoids a ToString of numbers or other primitives.
+    if (value->IsString()) {
+      *fields[i] = V8StringToStdString(isolate, value.As<String>());
     }
   }
   return init;
@@ -577,40 +655,16 @@ void URLPattern::Exec(const FunctionCallbackInfo<Value>& args) {
   auto env = Environment::GetCurrent(args);
 
   ada::url_pattern_input input;
-  std::optional<std::string> baseURL{};
-  std::string input_base;
-  if (args.Length() == 0 || args[0]->IsNullOrUndefined()) {
-    input = ada::url_pattern_init{};
-  } else if (args[0]->IsString()) {
-    Utf8Value input_value(env->isolate(), args[0].As<String>());
-    input_base = input_value.ToString();
-    input = std::string_view(input_base);
-  } else if (args[0]->IsObject()) {
-    auto maybeInput = URLPatternInit::FromJsObject(env, args[0].As<Object>());
-    if (!maybeInput.has_value()) return;
-    input = std::move(*maybeInput);
-  } else {
-    THROW_ERR_INVALID_ARG_TYPE(
-        env, "URLPattern input needs to be a string or an object");
+  std::optional<std::string_view> base_url;
+  MaybeStackBuffer<char> input_buf;
+  MaybeStackBuffer<char> base_buf;
+  if (!ExtractInputAndBaseURL(
+          env, args, &input, &base_url, &input_buf, &base_buf)) {
     return;
   }
 
-  if (args.Length() > 1 && !args[1]->IsUndefined()) {
-    if (args[1]->IsNull()) {
-      baseURL = std::string("null");
-    } else if (args[1]->IsString()) {
-      Utf8Value base_url_value(env->isolate(), args[1].As<String>());
-      baseURL = base_url_value.ToStringView();
-    } else {
-      THROW_ERR_INVALID_ARG_TYPE(env, "baseURL must be a string");
-      return;
-    }
-  }
-
   Local<Value> result;
-  std::optional<std::string_view> baseURL_opt =
-      baseURL ? std::optional<std::string_view>(*baseURL) : std::nullopt;
-  if (!url_pattern->Exec(env, input, baseURL_opt).ToLocal(&result)) {
+  if (!url_pattern->Exec(env, input, base_url).ToLocal(&result)) {
     THROW_ERR_OPERATION_FAILED(env, "Failed to exec URLPattern");
     return;
   }
@@ -623,39 +677,15 @@ void URLPattern::Test(const FunctionCallbackInfo<Value>& args) {
   auto env = Environment::GetCurrent(args);
 
   ada::url_pattern_input input;
-  std::optional<std::string> baseURL{};
-  std::string input_base;
-  if (args.Length() == 0 || args[0]->IsNullOrUndefined()) {
-    input = ada::url_pattern_init{};
-  } else if (args[0]->IsString()) {
-    Utf8Value input_value(env->isolate(), args[0].As<String>());
-    input_base = input_value.ToString();
-    input = std::string_view(input_base);
-  } else if (args[0]->IsObject()) {
-    auto maybeInput = URLPatternInit::FromJsObject(env, args[0].As<Object>());
-    if (!maybeInput.has_value()) return;
-    input = std::move(*maybeInput);
-  } else {
-    THROW_ERR_INVALID_ARG_TYPE(
-        env, "URLPattern input needs to be a string or an object");
+  std::optional<std::string_view> base_url;
+  MaybeStackBuffer<char> input_buf;
+  MaybeStackBuffer<char> base_buf;
+  if (!ExtractInputAndBaseURL(
+          env, args, &input, &base_url, &input_buf, &base_buf)) {
     return;
   }
 
-  if (args.Length() > 1 && !args[1]->IsUndefined()) {
-    if (args[1]->IsNull()) {
-      baseURL = std::string("null");
-    } else if (args[1]->IsString()) {
-      Utf8Value base_url_value(env->isolate(), args[1].As<String>());
-      baseURL = base_url_value.ToStringView();
-    } else {
-      THROW_ERR_INVALID_ARG_TYPE(env, "baseURL must be a string");
-      return;
-    }
-  }
-
-  std::optional<std::string_view> baseURL_opt =
-      baseURL ? std::optional<std::string_view>(*baseURL) : std::nullopt;
-  args.GetReturnValue().Set(url_pattern->Test(env, input, baseURL_opt));
+  args.GetReturnValue().Set(url_pattern->Test(env, input, base_url));
 }
 
 #define URL_PATTERN_COMPONENT_GETTERS(uppercase_name, lowercase_name)          \

--- a/test/parallel/test-urlpattern-fast-path.js
+++ b/test/parallel/test-urlpattern-fast-path.js
@@ -1,0 +1,130 @@
+'use strict';
+
+// Tests for the URLPattern constructor / test / exec C++ fast paths.
+
+require('../common');
+const assert = require('assert');
+const { URLPattern } = require('url');
+
+{
+  const pattern = new URLPattern('https://example.com/foo');
+  assert.strictEqual(pattern.protocol, 'https');
+  assert.strictEqual(pattern.hostname, 'example.com');
+  assert.strictEqual(pattern.pathname, '/foo');
+  assert.strictEqual(pattern.test('https://example.com/foo'), true);
+  assert.strictEqual(pattern.test('https://example.com/bar'), false);
+  const result = pattern.exec('https://example.com/foo');
+  assert.strictEqual(result.hostname.input, 'example.com');
+  assert.strictEqual(result.pathname.input, '/foo');
+  assert.strictEqual(result.protocol.input, 'https');
+}
+
+{
+  const pattern = new URLPattern('/foo', 'https://example.com');
+  assert.strictEqual(pattern.protocol, 'https');
+  assert.strictEqual(pattern.hostname, 'example.com');
+  assert.strictEqual(pattern.pathname, '/foo');
+  assert.strictEqual(pattern.test('https://example.com/foo'), true);
+  assert.strictEqual(pattern.test('/foo', 'https://example.com'), true);
+  const result = pattern.exec('/foo', 'https://example.com');
+  assert.strictEqual(result.hostname.input, 'example.com');
+  assert.strictEqual(result.pathname.input, '/foo');
+}
+
+{
+  const pattern = new URLPattern({
+    pathname: '/foo',
+    search: 'bar',
+    hash: 'baz',
+    baseURL: 'https://example.com:8080',
+  });
+  assert.strictEqual(pattern.protocol, 'https');
+  assert.strictEqual(pattern.hostname, 'example.com');
+  assert.strictEqual(pattern.port, '8080');
+  assert.strictEqual(pattern.pathname, '/foo');
+  assert.strictEqual(pattern.search, 'bar');
+  assert.strictEqual(pattern.hash, 'baz');
+  assert.strictEqual(
+    pattern.test('https://example.com:8080/foo?bar#baz'),
+    true,
+  );
+}
+
+{
+  // Non-string init members are ignored.
+  const pattern = new URLPattern({ pathname: '/foo', port: 8080 });
+  assert.strictEqual(pattern.pathname, '/foo');
+  assert.strictEqual(pattern.port, '*');
+}
+
+{
+  const pattern = new URLPattern({
+    hostname: 'xn--caf-dma.com',
+    pathname: '/café',
+  });
+  assert.strictEqual(pattern.hostname, 'xn--caf-dma.com');
+  assert.strictEqual(pattern.pathname, '/caf%C3%A9');
+  assert.strictEqual(
+    pattern.test({ hostname: 'xn--caf-dma.com', pathname: '/café' }),
+    true,
+  );
+  const result = pattern.exec({
+    hostname: 'xn--caf-dma.com',
+    pathname: '/café',
+  });
+  assert.strictEqual(result.hostname.input, 'xn--caf-dma.com');
+}
+
+{
+  const pattern = new URLPattern({ pathname: '/:value' });
+  const result = pattern.exec('https://example.com/test');
+  assert.strictEqual(result.pathname.groups.value, 'test');
+  assert.strictEqual(result.pathname.input, '/test');
+}
+
+{
+  const pattern = new URLPattern({ pathname: '/([a-z]+)' });
+  assert.strictEqual(pattern.hasRegExpGroups, true);
+  assert.strictEqual(pattern.test({ pathname: '/abc' }), true);
+  assert.strictEqual(pattern.test({ pathname: '/123' }), false);
+  const result = pattern.exec({ pathname: '/abc' });
+  assert.strictEqual(result.pathname.groups['0'], 'abc');
+}
+
+{
+  const pattern = new URLPattern('https://*.example.com/foo');
+  assert.strictEqual(pattern.test('https://sub.example.com/foo'), true);
+  assert.strictEqual(pattern.test('https://example.com/foo'), false);
+  const result = pattern.exec('https://sub.example.com/foo');
+  assert.strictEqual(result.hostname.input, 'sub.example.com');
+  assert.strictEqual(result.pathname.input, '/foo');
+}
+
+{
+  // Constructor-string pattern used by the urlpattern-* benchmarks.
+  const pattern = new URLPattern('https://(sub.)?example(.com/)foo');
+  assert.strictEqual(pattern.hostname, '(sub.)?example(.com/)foo');
+  assert.strictEqual(pattern.test('https://sub.example.com/foo'), false);
+  assert.strictEqual(pattern.exec('https://sub.example.com/foo'), null);
+}
+
+{
+  const pattern = new URLPattern({ pathname: '/FOO' }, { ignoreCase: true });
+  assert.strictEqual(pattern.test({ pathname: '/foo' }), true);
+  assert.strictEqual(pattern.test({ pathname: '/FOO' }), true);
+}
+
+{
+  const pattern = new URLPattern();
+  assert.strictEqual(pattern.protocol, '*');
+  assert.strictEqual(pattern.test('https://example.com/'), true);
+  assert.strictEqual(pattern.test(undefined), true);
+  assert.notStrictEqual(pattern.exec('https://example.com/'), null);
+}
+
+{
+  const pattern = new URLPattern({ protocol: 'https' });
+  assert.strictEqual(pattern.test('https://example.com', undefined), true);
+  assert.strictEqual(pattern.test('https://example.com', null), false);
+  assert.strictEqual(pattern.exec('https://example.com', null), null);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This speeds up WHATWG `URLPattern` constructor, `test()`, and `exec()` without changing observable behavior.

Independent of the `new URL()` parse PR (https://github.com/nodejs/node/pull/65361) and the `URLSearchParams` PR (https://github.com/nodejs/node/pull/65363).

## What changed

C++ only (`src/node_url_pattern.cc`):

- **String input:** copy one-byte ASCII V8 strings with `ValueView` + `memcpy` into a stack buffer and pass a `string_view` into Ada. Drop the extra `std::string` copy that `BufferValue`/`Utf8Value::ToString()` used to make. Non-ASCII still goes through `Utf8Value`.
- **Object init:** look up the nine interned component keys and assign fields by index. Skip UTF-8-converting each key name and the string-compare chain. Non-string members are still ignored.
- **Regexp provider:** convert pattern/input strings with `ToV8Value` and use `isolate->GetCurrentContext()` instead of `Environment::GetCurrent`.
- **`test` / `exec`:** share argument parsing so both paths keep the same WebIDL null/undefined/`"null"` baseURL behavior.

Ada still owns its parsed state; `string_view`s only live for the duration of the C++ call. `ValueView` is destroyed before any V8 heap allocation.

## Tests

- `test/parallel/test-urlpattern.js`, `test-urlpattern-types.js`, `test-urlpattern-invalidthis.js`, and `test-urlpattern-fast-path.js` all pass
- WPT `test/wpt/test-urlpattern.js`: 743 passed, 0 unexpected failures

## Review follow-up

- Dropped the local `NewStringFromUtf8View` helper in favor of `ToV8Value`
- `CopyV8StringToBuffer` takes a pointer, matching project convention for mutating arguments
- Author and `Signed-off-by` are Yagiz Nizipli (human DCO)

Assisted-by: Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01206-dcf2-75c5-8c4e-f60e306c603e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01206-dcf2-75c5-8c4e-f60e306c603e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>