### PR TITLE
module: rebase clearCache and address review comments

### DIFF
--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -253,7 +253,7 @@ function loadFresh() {
     parentURL: pathToFileURL(__filename),
     resolver: 'require',
   });
-  return require('./app.js'); // eslint-disable-line node-core/no-duplicate-requires
+  return require('./app.js');
 }
 
 const first = loadFresh();
@@ -2239,10 +2239,10 @@ returned object contains the following keys:
 * `columnNumber` {number} The 1-indexed columnNumber of the
   corresponding call site in the original source
 
-[ECMA-262 spec considerations]: #ecma-262-spec-considerations
 [CommonJS]: modules.md
 [Conditional exports]: packages.md#conditional-exports
 [Customization hooks]: #customization-hooks
+[ECMA-262 spec considerations]: #ecma-262-spec-considerations
 [ES Modules]: esm.md
 [Permission Model]: permissions.md#permission-model
 [Source Map]: https://tc39.es/ecma426/

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -75,50 +75,62 @@ added: REPLACEME
 > Stability: 1.0 - Early development
 
 * `specifier` {string|URL} The module specifier, as it would have been passed to
-  `import()` or `require()`.
-* `options` {Object}
-  * `parentURL` {string|URL} The parent URL used to resolve the specifier. Parent identity
-    is part of the resolution cache key. For CommonJS, pass `pathToFileURL(__filename)`.
-    For ES modules, pass `import.meta.url`.
-  * `resolver` {string} Specifies how resolution should be performed. Must be either
-    `'import'` or `'require'`.
+  `import()` or `require()`. When `resolver` is `'require'`, this must be a
+  string (the same kind of path or identifier `require()` accepts). Passing a
+  `URL` object with `resolver: 'require'` throws `ERR_INVALID_ARG_TYPE`.
+* `options` {Object} Required.
+  * `parentURL` {string|URL} Required. The parent URL used to resolve the
+    specifier. Parent identity is part of the resolution cache key. For
+    CommonJS, pass `pathToFileURL(__filename)`. For ES modules, pass
+    `import.meta.url`.
+  * `resolver` {string} Required. How resolution should be performed. Must be
+    either `'import'` or `'require'`.
   * `importAttributes` {Object} Optional import attributes. Only meaningful when
     `resolver` is `'import'`.
 
 Clears the module resolution and module caches for a module. This enables
-reload patterns similar to deleting from `require.cache` in CommonJS, and is useful for
-hot module reload.
+reload patterns similar to deleting from `require.cache` in CommonJS, and is
+useful for hot module reload.
 
-The specifier is resolved using the chosen `resolver`, then the resolved module is removed
-from all internal caches (CommonJS `require` cache, CommonJS resolution caches, ESM resolve
-cache, ESM load cache, and ESM translators cache). When `resolver` is `'import'`,
-`importAttributes` are part of the ESM resolve-cache key, so only the exact
-`(specifier, parentURL, importAttributes)` resolution entry is removed. When a `file:` URL is
-resolved, cached module jobs for the same file path are cleared even if they differ by search
-or hash. This means clearing `'./mod.mjs?v=1'` will also clear `'./mod.mjs?v=2'` and any
+Both `options.parentURL` and `options.resolver` are required. There is no
+recursive option: `clearCache` invalidates only the resolved module, not its
+dependencies. Callers that need to reload a graph must track and clear each
+module themselves.
+
+The specifier is resolved using the chosen `resolver`, then the resolved module
+is removed from all Node.js internal caches (CommonJS `require` cache, CommonJS
+resolution caches, ESM resolve cache, ESM load cache, and ESM translators
+cache). When `resolver` is `'import'`, `importAttributes` are part of the ESM
+resolve-cache key, so only the exact `(specifier, parentURL, importAttributes)`
+resolution entry is removed. When a `file:` URL is resolved, cached module jobs
+for the same file path are cleared even if they differ by search or hash. This
+means clearing `'./mod.mjs?v=1'` will also clear `'./mod.mjs?v=2'` and any
 other query/hash variants that resolve to the same file.
 
-When `resolver` is `'require'`, cached `package.json` data for the resolved module's package
-is also cleared so that updated exports/imports conditions are picked up on the next
-resolution.
+When `resolver` is `'require'`, cached `package.json` data for the resolved
+module's package is also cleared so that updated exports/imports conditions are
+picked up on the next resolution.
 
 Clearing a module does not clear cached entries for its dependencies. When using
-`resolver: 'import'`, resolution cache entries for other specifiers that resolve to the
-same target are not cleared — only the exact `(specifier, parentURL, importAttributes)`
-entry is removed. The module cache itself is cleared by resolved file path, so all
-specifiers pointing to the same file will see a fresh execution on next import.
+`resolver: 'import'`, resolution cache entries for other specifiers that resolve
+to the same target are not cleared — only the exact
+`(specifier, parentURL, importAttributes)` entry is removed. The module cache
+itself is cleared by resolved file path, so all specifiers pointing to the same
+file will see a fresh execution on next import.
 
 #### Memory retention and static imports
 
-`clearCache` only removes references from the Node.js **JavaScript-level** caches
-(the ESM load cache, resolve cache, CJS `require.cache`, and related structures).
-It does **not** affect V8-internal module graph references.
+`clearCache` only removes references from the Node.js internal caches (the ESM
+load cache, resolve cache, CJS `require.cache`, and related structures). It does
+**not** affect references created by user modules, for example through a static
+`import`. If one module imports another, `clearCache` will not clean up that
+link. It only clears references from Node.js internal caches to user modules.
 
-When a module M is **statically imported** by a live parent module P
-(i.e., via a top-level `import … from '…'` statement that has already been
-evaluated), V8's module instantiation creates a permanent internal strong
-reference from P's compiled module record to M's module record. Calling
-`clearCache(M)` cannot sever that link. Consequences:
+When a module M is **statically imported** by a live parent module P (via a
+top-level `import … from '…'` statement that has already been evaluated), the
+engine keeps a permanent internal strong reference from P's compiled module
+record to M's module record. Calling `clearCache(M)` cannot sever that link.
+Consequences:
 
 * The old instance of M **stays alive in memory** for as long as P is alive,
   regardless of how many times M is cleared and re-imported.
@@ -130,12 +142,13 @@ reference from P's compiled module record to M's module record. Calling
   cycles.
 
 For **dynamically imported** modules (`await import('./M.mjs')` with no live
-static parent holding the result), the old `ModuleWrap` becomes eligible for
+static parent holding the result), the old module becomes eligible for
 garbage collection once `clearCache` removes it from Node.js caches and all
-JS-land references (e.g., stored namespace objects) are dropped.
+JavaScript references (for example, stored namespace objects) are dropped.
 
 The safest pattern for hot-reload of ES modules is to use cache-busting search
-parameters (so each version is a distinct module URL) and use dynamic imports for modules that need to be reloaded:
+parameters (so each version is a distinct module URL) and use dynamic imports
+for modules that need to be reloaded:
 
 #### ECMA-262 spec considerations
 
@@ -169,11 +182,14 @@ watch(base, async () => {
 
 #### Examples
 
+Relative specifiers are resolved against `parentURL`, not against the process
+working directory:
+
 ```mjs
 import { clearCache } from 'node:module';
 
+// Resolves to the `mod.mjs` sibling of *this* module, then clears it.
 await import('./mod.mjs');
-
 clearCache('./mod.mjs', {
   parentURL: import.meta.url,
   resolver: 'import',
@@ -193,6 +209,56 @@ clearCache('./mod.js', {
 });
 require('./mod.js'); // eslint-disable-line node-core/no-duplicate-requires
 // re-executes the module
+```
+
+Bare specifiers are resolved the same way `import`/`require` would resolve them
+from `parentURL` (including `node_modules` lookup and `package.json` `"exports"`):
+
+```mjs
+import { clearCache } from 'node:module';
+
+await import('some-package');
+clearCache('some-package', {
+  parentURL: import.meta.url,
+  resolver: 'import',
+});
+await import('some-package'); // re-executes the package entry point
+```
+
+An absolute `file:` URL still requires `parentURL` and `resolver`. The URL is
+the cache key; `parentURL` is used if the loader needs to resolve it again
+(for example, through customization hooks):
+
+```mjs
+import { clearCache } from 'node:module';
+
+const url = new URL('./mod.mjs', import.meta.url);
+await import(url);
+clearCache(url, {
+  parentURL: import.meta.url,
+  resolver: 'import',
+});
+await import(url); // re-executes the module
+```
+
+Reloading a CommonJS module between tests (the ESM equivalent should use
+cache-busting search parameters; see [ECMA-262 spec considerations][]):
+
+```cjs
+const { clearCache } = require('node:module');
+const { pathToFileURL } = require('node:url');
+
+function loadFresh() {
+  clearCache('./app.js', {
+    parentURL: pathToFileURL(__filename),
+    resolver: 'require',
+  });
+  return require('./app.js'); // eslint-disable-line node-core/no-duplicate-requires
+}
+
+const first = loadFresh();
+const second = loadFresh();
+// `first` and `second` are independently evaluated copies.
 ```
 
 ### `module.findPackageJSON(specifier[, base])`
@@ -2173,6 +2239,7 @@ returned object contains the following keys:
 * `columnNumber` {number} The 1-indexed columnNumber of the
   corresponding call site in the original source
 
+[ECMA-262 spec considerations]: #ecma-262-spec-considerations
 [CommonJS]: modules.md
 [Conditional exports]: packages.md#conditional-exports
 [Customization hooks]: #customization-hooks

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -66,6 +66,135 @@ const require = createRequire(import.meta.url);
 const siblingModule = require('./sibling-module');
 ```
 
+### `module.clearCache(specifier, options)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1.0 - Early development
+
+* `specifier` {string|URL} The module specifier, as it would have been passed to
+  `import()` or `require()`.
+* `options` {Object}
+  * `parentURL` {string|URL} The parent URL used to resolve the specifier. Parent identity
+    is part of the resolution cache key. For CommonJS, pass `pathToFileURL(__filename)`.
+    For ES modules, pass `import.meta.url`.
+  * `resolver` {string} Specifies how resolution should be performed. Must be either
+    `'import'` or `'require'`.
+  * `importAttributes` {Object} Optional import attributes. Only meaningful when
+    `resolver` is `'import'`.
+
+Clears the module resolution and module caches for a module. This enables
+reload patterns similar to deleting from `require.cache` in CommonJS, and is useful for
+hot module reload.
+
+The specifier is resolved using the chosen `resolver`, then the resolved module is removed
+from all internal caches (CommonJS `require` cache, CommonJS resolution caches, ESM resolve
+cache, ESM load cache, and ESM translators cache). When `resolver` is `'import'`,
+`importAttributes` are part of the ESM resolve-cache key, so only the exact
+`(specifier, parentURL, importAttributes)` resolution entry is removed. When a `file:` URL is
+resolved, cached module jobs for the same file path are cleared even if they differ by search
+or hash. This means clearing `'./mod.mjs?v=1'` will also clear `'./mod.mjs?v=2'` and any
+other query/hash variants that resolve to the same file.
+
+When `resolver` is `'require'`, cached `package.json` data for the resolved module's package
+is also cleared so that updated exports/imports conditions are picked up on the next
+resolution.
+
+Clearing a module does not clear cached entries for its dependencies. When using
+`resolver: 'import'`, resolution cache entries for other specifiers that resolve to the
+same target are not cleared — only the exact `(specifier, parentURL, importAttributes)`
+entry is removed. The module cache itself is cleared by resolved file path, so all
+specifiers pointing to the same file will see a fresh execution on next import.
+
+#### Memory retention and static imports
+
+`clearCache` only removes references from the Node.js **JavaScript-level** caches
+(the ESM load cache, resolve cache, CJS `require.cache`, and related structures).
+It does **not** affect V8-internal module graph references.
+
+When a module M is **statically imported** by a live parent module P
+(i.e., via a top-level `import … from '…'` statement that has already been
+evaluated), V8's module instantiation creates a permanent internal strong
+reference from P's compiled module record to M's module record. Calling
+`clearCache(M)` cannot sever that link. Consequences:
+
+* The old instance of M **stays alive in memory** for as long as P is alive,
+  regardless of how many times M is cleared and re-imported.
+* A fresh `import(M)` after clearing will create a **separate** module instance
+  that new importers see. P, however, continues to use the original instance —
+  the two coexist simultaneously (sometimes called a "split-brain" state).
+* This is a **bounded** retention: one stale module instance per cleared module
+  per live static parent. It does not grow unboundedly across clear/re-import
+  cycles.
+
+For **dynamically imported** modules (`await import('./M.mjs')` with no live
+static parent holding the result), the old `ModuleWrap` becomes eligible for
+garbage collection once `clearCache` removes it from Node.js caches and all
+JS-land references (e.g., stored namespace objects) are dropped.
+
+The safest pattern for hot-reload of ES modules is to use cache-busting search
+parameters (so each version is a distinct module URL) and use dynamic imports for modules that need to be reloaded:
+
+#### ECMA-262 spec considerations
+
+Re-importing the exact same `(specifier, parentURL, importAttributes)` tuple after clearing the module cache
+technically violates the idempotency invariant of the ECMA-262
+[`HostLoadImportedModule`][] host hook, which expects that the same module request always
+returns the same Module Record for a given referrer. The result of violating this requirement
+is undefined — e.g. it can lead to crashes. For spec-compliant usage, use
+cache-busting search parameters so that each reload uses a distinct module request:
+
+```mjs
+import { clearCache } from 'node:module';
+import { watch } from 'node:fs';
+
+let version = 0;
+const base = new URL('./app.mjs', import.meta.url);
+
+watch(base, async () => {
+  // Clear the module cache for the previous version.
+  clearCache(new URL(`${base.href}?v=${version}`), {
+    parentURL: import.meta.url,
+    resolver: 'import',
+  });
+  version++;
+  // Re-import with a new search parameter — this is a distinct module request
+  // and does not violate the ECMA-262 invariant.
+  const mod = await import(`${base.href}?v=${version}`);
+  console.log('reloaded:', mod);
+});
+```
+
+#### Examples
+
+```mjs
+import { clearCache } from 'node:module';
+
+await import('./mod.mjs');
+
+clearCache('./mod.mjs', {
+  parentURL: import.meta.url,
+  resolver: 'import',
+});
+await import('./mod.mjs'); // re-executes the module
+```
+
+```cjs
+const { clearCache } = require('node:module');
+const { pathToFileURL } = require('node:url');
+
+require('./mod.js');
+
+clearCache('./mod.js', {
+  parentURL: pathToFileURL(__filename),
+  resolver: 'require',
+});
+require('./mod.js'); // eslint-disable-line node-core/no-duplicate-requires
+// re-executes the module
+```
+
 ### `module.findPackageJSON(specifier[, base])`
 
 <!-- YAML
@@ -2057,6 +2186,7 @@ returned object contains the following keys:
 [`--enable-source-maps`]: cli.md#--enable-source-maps
 [`--import`]: cli.md#--importmodule
 [`--require`]: cli.md#-r---require-module
+[`HostLoadImportedModule`]: https://tc39.es/ecma262/#sec-HostLoadImportedModule
 [`NODE_COMPILE_CACHE=dir`]: cli.md#node_compile_cachedir
 [`NODE_COMPILE_CACHE_PORTABLE=1`]: cli.md#node_compile_cache_portable1
 [`NODE_DISABLE_COMPILE_CACHE=1`]: cli.md#node_disable_compile_cache1

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -111,6 +111,8 @@ const kIsExecuting = Symbol('kIsExecuting');
 const kURL = Symbol('kURL');
 const kFormat = Symbol('kFormat');
 
+const relativeResolveCache = { __proto__: null };
+
 // Set first due to cycle with ESM loader functions.
 module.exports = {
   kModuleSource,
@@ -119,6 +121,7 @@ module.exports = {
   kModuleCircularVisited,
   initializeCJS,
   Module,
+  clearCJSResolutionCaches,
   findLongestRegisteredExtension,
   resolveForCJSWithHooks,
   loadSourceForCJSWithHooks: loadSource,
@@ -229,7 +232,29 @@ let { startTimer, endTimer } = debugWithTimer('module_timer', (start, end) => {
 const { tracingChannel } = require('diagnostics_channel');
 const onRequire = getLazy(() => tracingChannel('module.require'));
 
-const relativeResolveCache = { __proto__: null };
+/**
+ * Clear all entries in the CJS relative resolve cache and _pathCache
+ * that map to a given filename. This is needed by clearCache() to
+ * prevent stale resolution results after a module is removed.
+ * @param {string} filename The resolved filename to purge.
+ */
+function clearCJSResolutionCaches(filename) {
+  // Clear from relativeResolveCache (keyed by parent.path + '\x00' + request).
+  const relKeys = ObjectKeys(relativeResolveCache);
+  for (let i = 0; i < relKeys.length; i++) {
+    if (relativeResolveCache[relKeys[i]] === filename) {
+      delete relativeResolveCache[relKeys[i]];
+    }
+  }
+
+  // Clear from Module._pathCache (keyed by request + '\x00' + paths).
+  const pathKeys = ObjectKeys(Module._pathCache);
+  for (let i = 0; i < pathKeys.length; i++) {
+    if (Module._pathCache[pathKeys[i]] === filename) {
+      delete Module._pathCache[pathKeys[i]];
+    }
+  }
+}
 
 let requireDepth = 0;
 let isPreloading = false;

--- a/lib/internal/modules/clear.js
+++ b/lib/internal/modules/clear.js
@@ -1,0 +1,289 @@
+'use strict';
+
+const {
+  ArrayIsArray,
+  ArrayPrototypeIndexOf,
+  ArrayPrototypePush,
+  ArrayPrototypeSplice,
+  ObjectKeys,
+  StringPrototypeCharCodeAt,
+  StringPrototypeStartsWith,
+} = primordials;
+
+const {
+  Module,
+  resolveForCJSWithHooks,
+  clearCJSResolutionCaches,
+} = require('internal/modules/cjs/loader');
+const { getFilePathFromFileURL } = require('internal/modules/helpers');
+const { fileURLToPath, isURL, URLParse, pathToFileURL } = require('internal/url');
+const { emitExperimentalWarning, kEmptyObject, isWindows } = require('internal/util');
+const { validateObject, validateOneOf, validateString } = require('internal/validators');
+const {
+  codes: {
+    ERR_INVALID_ARG_VALUE,
+  },
+} = require('internal/errors');
+const { CHAR_DOT } = require('internal/constants');
+const path = require('path');
+const {
+  privateSymbols: {
+    module_first_parent_private_symbol: kFirstModuleParent,
+    module_last_parent_private_symbol: kLastModuleParent,
+  },
+} = internalBinding('util');
+
+/**
+ * Normalize the parent URL for cache clearing.
+ * @param {string|URL} parentURL
+ * @returns {{ parentURL: string, parentPath: string|undefined }}
+ */
+function normalizeClearCacheParent(parentURL) {
+  if (isURL(parentURL)) {
+    let parentPath;
+    if (parentURL.protocol === 'file:' && parentURL.search === '' && parentURL.hash === '') {
+      parentPath = fileURLToPath(parentURL);
+    }
+    return { __proto__: null, parentURL: parentURL.href, parentPath };
+  }
+
+  validateString(parentURL, 'options.parentURL');
+  const url = URLParse(parentURL);
+  if (!url) {
+    throw new ERR_INVALID_ARG_VALUE('options.parentURL', parentURL,
+                                    'must be a URL');
+  }
+
+  let parentPath;
+  if (url.protocol === 'file:' && url.search === '' && url.hash === '') {
+    parentPath = fileURLToPath(url);
+  }
+  return { __proto__: null, parentURL: url.href, parentPath };
+}
+
+/**
+ * Create a synthetic parent module for CJS resolution.
+ * @param {string} parentPath
+ * @returns {Module}
+ */
+function createParentModuleForClearCache(parentPath) {
+  const parent = new Module(parentPath);
+  parent.filename = parentPath;
+  parent.paths = Module._nodeModulePaths(path.dirname(parentPath));
+  return parent;
+}
+
+/**
+ * Resolve a cache filename for CommonJS.
+ * Always goes through resolveForCJSWithHooks so that registered hooks
+ * are respected. The specifier is passed as-is: if hooks are registered,
+ * they handle any URL interpretation; if not, it is treated as a plain
+ * path/identifier (matching how require() interprets its argument).
+ * @param {string|URL} specifier
+ * @param {string|undefined} parentPath
+ * @returns {string|null}
+ */
+function resolveClearCacheFilename(specifier, parentPath) {
+  // Pass the specifier through as-is. When hooks are registered they
+  // receive the raw value; without hooks CJS resolution treats it as
+  // a plain path or bare name, consistent with how require() behaves.
+  const request = isURL(specifier) ? specifier.href : specifier;
+
+  if (!parentPath && isRelative(request)) {
+    return null;
+  }
+
+  const parent = parentPath ? createParentModuleForClearCache(parentPath) : null;
+  try {
+    const { filename, format } = resolveForCJSWithHooks(request, parent, false, false);
+    if (format === 'builtin') {
+      return null;
+    }
+    return filename;
+  } catch {
+    // Resolution can fail for non-file specifiers without hooks - return null
+    // to silently skip clearing rather than throwing.
+    return null;
+  }
+}
+
+/**
+ * Resolve a cache URL for ESM.
+ * Always goes through the loader's resolveSync so that registered hooks
+ * (e.g. hooks that redirect specifiers) are respected.
+ * @param {string|URL} specifier
+ * @param {string} parentURL
+ * @returns {string}
+ */
+function resolveClearCacheURL(specifier, parentURL) {
+  const cascadedLoader =
+    require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
+  const specifierStr = isURL(specifier) ? specifier.href : specifier;
+  const request = { specifier: specifierStr, __proto__: null };
+  return cascadedLoader.resolveSync(parentURL, request).url;
+}
+
+/**
+ * Remove cached module references from parent children arrays.
+ * @param {Module} targetModule
+ * @returns {boolean} true if any references were removed.
+ */
+function deleteModuleFromParents(targetModule) {
+  const keys = ObjectKeys(Module._cache);
+  let deleted = false;
+  for (let i = 0; i < keys.length; i++) {
+    const cachedModule = Module._cache[keys[i]];
+    if (cachedModule?.[kFirstModuleParent] === targetModule) {
+      cachedModule[kFirstModuleParent] = undefined;
+      deleted = true;
+    }
+    if (cachedModule?.[kLastModuleParent] === targetModule) {
+      cachedModule[kLastModuleParent] = undefined;
+      deleted = true;
+    }
+    const children = cachedModule?.children;
+    if (!ArrayIsArray(children)) {
+      continue;
+    }
+    const index = ArrayPrototypeIndexOf(children, targetModule);
+    if (index !== -1) {
+      ArrayPrototypeSplice(children, index, 1);
+      deleted = true;
+    }
+  }
+  return deleted;
+}
+
+/**
+ * Remove load cache entries for a URL and its file-path variants.
+ * @param {import('internal/modules/esm/module_map').LoadCache} loadCache
+ * @param {string} url
+ * @returns {boolean} true if any entries were deleted.
+ */
+function deleteLoadCacheEntries(loadCache, url) {
+  let deleted = loadCache.deleteAll(url);
+  const filename = getFilePathFromFileURL(url);
+  if (!filename) {
+    return deleted;
+  }
+
+  const urls = [];
+  for (const entry of loadCache) {
+    ArrayPrototypePush(urls, entry[0]);
+  }
+
+  for (let i = 0; i < urls.length; i++) {
+    const cachedURL = urls[i];
+    if (cachedURL === url) {
+      continue;
+    }
+    const cachedFilename = getFilePathFromFileURL(cachedURL);
+    if (cachedFilename === filename) {
+      loadCache.deleteAll(cachedURL);
+      deleted = true;
+    }
+  }
+
+  return deleted;
+}
+
+/**
+ * Checks if a path is relative
+ * @param {string} pathToCheck the target path
+ * @returns {boolean} true if the path is relative, false otherwise
+ */
+function isRelative(pathToCheck) {
+  if (StringPrototypeCharCodeAt(pathToCheck, 0) !== CHAR_DOT) { return false; }
+
+  return pathToCheck.length === 1 || pathToCheck === '..' ||
+  StringPrototypeStartsWith(pathToCheck, './') ||
+  StringPrototypeStartsWith(pathToCheck, '../') ||
+  ((isWindows && StringPrototypeStartsWith(pathToCheck, '.\\')) ||
+  StringPrototypeStartsWith(pathToCheck, '..\\'));
+}
+
+/**
+ * Clear module resolution and module caches.
+ * @param {string|URL} specifier What would've been passed into import() or require().
+ * @param {{
+ *   parentURL: string|URL,
+ *   importAttributes?: Record<string, string>,
+ *   resolver: 'import'|'require',
+ * }} options
+ */
+function clearCache(specifier, options) {
+  emitExperimentalWarning('module.clearCache');
+
+  const isSpecifierURL = isURL(specifier);
+  if (!isSpecifierURL) {
+    validateString(specifier, 'specifier');
+  }
+
+  validateObject(options, 'options');
+  const { parentURL, parentPath } = normalizeClearCacheParent(options.parentURL);
+
+  const { resolver } = options;
+  validateOneOf(resolver, 'options.resolver', ['import', 'require']);
+
+  const importAttributes = options.importAttributes ?? kEmptyObject;
+  if (options.importAttributes !== undefined) {
+    validateObject(options.importAttributes, 'options.importAttributes');
+  }
+
+  // Resolve before clearing so resolution-cache entries are still available.
+  let resolvedFilename = null;
+  let resolvedURL = null;
+
+  if (resolver === 'require') {
+    resolvedFilename = resolveClearCacheFilename(specifier, parentPath);
+    if (resolvedFilename) {
+      resolvedURL = pathToFileURL(resolvedFilename).href;
+    }
+  } else {
+    resolvedURL = resolveClearCacheURL(specifier, parentURL);
+    if (resolvedURL) {
+      resolvedFilename = getFilePathFromFileURL(resolvedURL);
+    }
+  }
+
+  // ESM resolution cache entries are keyed by
+  // (specifier, parentURL, importAttributes).
+  if (resolver === 'import') {
+    const specifierStr = isSpecifierURL ? specifier.href : specifier;
+    const cascadedLoader =
+      require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
+    cascadedLoader.deleteResolveCacheEntry(specifierStr, parentURL, importAttributes);
+  }
+
+  if (resolver === 'require' && resolvedFilename) {
+    const { getNearestParentPackageJSON, clearPackageJSONCache } =
+      require('internal/modules/package_json_reader');
+    const pkg = getNearestParentPackageJSON(resolvedFilename);
+    if (pkg?.path) {
+      clearPackageJSONCache(pkg.path);
+    }
+  }
+
+  // Clear module caches everywhere in Node.js.
+  if (resolvedFilename) {
+    const cachedModule = Module._cache[resolvedFilename];
+    if (cachedModule !== undefined) {
+      delete Module._cache[resolvedFilename];
+      deleteModuleFromParents(cachedModule);
+    }
+    // Also clear CJS resolution caches that point to this filename.
+    clearCJSResolutionCaches(resolvedFilename);
+  }
+
+  if (resolvedURL) {
+    const cascadedLoader =
+      require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
+    deleteLoadCacheEntries(cascadedLoader.loadCache, resolvedURL);
+    const { clearCjsCache } = require('internal/modules/esm/translators');
+    clearCjsCache(resolvedURL);
+  }
+}
+
+module.exports = {
+  clearCache,
+};

--- a/lib/internal/modules/clear.js
+++ b/lib/internal/modules/clear.js
@@ -21,6 +21,7 @@ const { emitExperimentalWarning, kEmptyObject, isWindows } = require('internal/u
 const { validateObject, validateOneOf, validateString } = require('internal/validators');
 const {
   codes: {
+    ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
   },
 } = require('internal/errors');
@@ -76,26 +77,21 @@ function createParentModuleForClearCache(parentPath) {
 /**
  * Resolve a cache filename for CommonJS.
  * Always goes through resolveForCJSWithHooks so that registered hooks
- * are respected. The specifier is passed as-is: if hooks are registered,
- * they handle any URL interpretation; if not, it is treated as a plain
- * path/identifier (matching how require() interprets its argument).
- * @param {string|URL} specifier
+ * are respected. The specifier is a string path/identifier, matching
+ * how require() interprets its argument. URL objects are rejected by
+ * clearCache() before this is called.
+ * @param {string} specifier
  * @param {string|undefined} parentPath
  * @returns {string|null}
  */
 function resolveClearCacheFilename(specifier, parentPath) {
-  // Pass the specifier through as-is. When hooks are registered they
-  // receive the raw value; without hooks CJS resolution treats it as
-  // a plain path or bare name, consistent with how require() behaves.
-  const request = isURL(specifier) ? specifier.href : specifier;
-
-  if (!parentPath && isRelative(request)) {
+  if (!parentPath && isRelative(specifier)) {
     return null;
   }
 
   const parent = parentPath ? createParentModuleForClearCache(parentPath) : null;
   try {
-    const { filename, format } = resolveForCJSWithHooks(request, parent, false, false);
+    const { filename, format } = resolveForCJSWithHooks(specifier, parent, false, false);
     if (format === 'builtin') {
       return null;
     }
@@ -205,6 +201,7 @@ function isRelative(pathToCheck) {
 /**
  * Clear module resolution and module caches.
  * @param {string|URL} specifier What would've been passed into import() or require().
+ *   When resolver is 'require', this must be a string.
  * @param {{
  *   parentURL: string|URL,
  *   importAttributes?: Record<string, string>,
@@ -224,6 +221,12 @@ function clearCache(specifier, options) {
 
   const { resolver } = options;
   validateOneOf(resolver, 'options.resolver', ['import', 'require']);
+
+  // require() does not accept URL objects. A string that happens to look like
+  // a file: URL is still treated as a path/identifier, matching require().
+  if (resolver === 'require' && isSpecifierURL) {
+    throw new ERR_INVALID_ARG_TYPE('specifier', 'string', specifier);
+  }
 
   const importAttributes = options.importAttributes ?? kEmptyObject;
   if (options.importAttributes !== undefined) {

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -162,18 +162,6 @@ class ModuleLoader {
   }
 
   /**
-   * Check if a cached resolution exists for a specific request.
-   * @param {string} specifier
-   * @param {string|undefined} parentURL
-   * @param {Record<string, string>} importAttributes
-   * @returns {boolean} true if an entry exists.
-   */
-  hasResolveCacheEntry(specifier, parentURL, importAttributes = { __proto__: null }) {
-    const serializedKey = this.#resolveCache.serializeKey(specifier, importAttributes);
-    return this.#resolveCache.has(serializedKey, parentURL);
-  }
-
-  /**
    * @see {AsyncLoaderHooks.isForAsyncLoaderHookWorker}
    * Shortcut to this.#asyncLoaderHooks.isForAsyncLoaderHookWorker.
    */

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -151,6 +151,29 @@ class ModuleLoader {
   loadCache = new LoadCache();
 
   /**
+   * Delete cached resolution for a specific request.
+   * @param {string} specifier
+   * @param {string|undefined} parentURL
+   * @param {Record<string, string>} importAttributes
+   * @returns {boolean} true if any entries were deleted.
+   */
+  deleteResolveCacheEntry(specifier, parentURL, importAttributes) {
+    return this.#resolveCache.deleteBySpecifier(specifier, parentURL, importAttributes);
+  }
+
+  /**
+   * Check if a cached resolution exists for a specific request.
+   * @param {string} specifier
+   * @param {string|undefined} parentURL
+   * @param {Record<string, string>} importAttributes
+   * @returns {boolean} true if an entry exists.
+   */
+  hasResolveCacheEntry(specifier, parentURL, importAttributes = { __proto__: null }) {
+    const serializedKey = this.#resolveCache.serializeKey(specifier, importAttributes);
+    return this.#resolveCache.has(serializedKey, parentURL);
+  }
+
+  /**
    * @see {AsyncLoaderHooks.isForAsyncLoaderHookWorker}
    * Shortcut to this.#asyncLoaderHooks.isForAsyncLoaderHookWorker.
    */

--- a/lib/internal/modules/esm/module_map.js
+++ b/lib/internal/modules/esm/module_map.js
@@ -6,6 +6,7 @@ const {
   ArrayPrototypeSort,
   JSONStringify,
   ObjectKeys,
+  ObjectPrototypeHasOwnProperty,
   SafeMap,
 } = primordials;
 const { kImplicitTypeAttribute } = require('internal/modules/esm/assert');
@@ -85,6 +86,29 @@ class ResolveCache extends SafeMap {
   has(serializedKey, parentURL) {
     return serializedKey in this.#getModuleCachedImports(parentURL);
   }
+
+  /**
+   * Delete a cached resolution for a specifier in a parent URL.
+   * @param {string} specifier
+   * @param {string|undefined} parentURL
+   * @param {Record<string,string>} importAttributes
+   * @returns {boolean} true if an entry was deleted.
+   */
+  deleteBySpecifier(specifier, parentURL, importAttributes) {
+    const entries = super.get(parentURL);
+    if (entries == null) {
+      return false;
+    }
+    const serializedKey = this.serializeKey(specifier, importAttributes);
+    if (!ObjectPrototypeHasOwnProperty(entries, serializedKey)) {
+      return false;
+    }
+    delete entries[serializedKey];
+    if (ObjectKeys(entries).length === 0) {
+      super.delete(parentURL);
+    }
+    return true;
+  }
 }
 
 /**
@@ -122,6 +146,16 @@ class LoadCache extends SafeMap {
     if (cached) {
       cached[type] = undefined;
     }
+  }
+
+  /**
+   * Delete all cached module jobs for a URL.
+   * @param {string} url
+   * @returns {boolean} true if an entry was deleted.
+   */
+  deleteAll(url) {
+    validateString(url, 'url');
+    return super.delete(url);
   }
 }
 

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -29,6 +29,7 @@ const {
   stringify,
   stripBOM,
   urlToFilename,
+  getFilePathFromFileURL,
 } = require('internal/modules/helpers');
 const { stripTypeScriptModuleTypes } = require('internal/modules/typescript');
 const {
@@ -194,6 +195,40 @@ function loadCJSModuleWithSpecialRequire(module, source, url, filename, isMain, 
 const cjsCache = new SafeMap();
 
 /**
+ * Remove cjsCache entries for a URL and its file-path variants.
+ * @param {string} url
+ * @returns {boolean} true if any entries were deleted.
+ */
+function clearCjsCache(url) {
+  let deleted = cjsCache.delete(url);
+  const filename = getFilePathFromFileURL(url);
+  if (!filename) {
+    return deleted;
+  }
+
+  const urls = [];
+  for (const entry of cjsCache) {
+    ArrayPrototypePush(urls, entry[0]);
+  }
+
+  for (let i = 0; i < urls.length; i++) {
+    const cachedURL = urls[i];
+    if (cachedURL === url) {
+      continue;
+    }
+    const cachedFilename = getFilePathFromFileURL(cachedURL);
+    if (cachedFilename === filename) {
+      cjsCache.delete(cachedURL);
+      deleted = true;
+    }
+  }
+
+  return deleted;
+}
+
+exports.clearCjsCache = clearCjsCache;
+
+/**
  * Creates a ModuleWrap object for a CommonJS module.
  * @param {string} url - The URL of the module.
  * @param {import('./loader').TranslateContext} translateContext Context for the translator
@@ -352,7 +387,11 @@ translators.set('require-commonjs-typescript', (url, translateContext, parentURL
  * @param {import('./loader').TranslateContext} translateContext Context for the translator
  */
 function loadCJSModuleWithModuleLoad(module, source, url, filename, isMain, translateContext) {
-  assert(module === CJSModule._cache[filename]);
+  // clearCache may have removed this entry while an import() is in-flight.
+  // Re-install so wrapModuleLoad finds the same module instance.
+  if (CJSModule._cache[filename] !== module) {
+    CJSModule._cache[filename] = module;
+  }
   debug(`loadCJSModuleWithModuleLoad ${url}`);
   let exports;
   if (translateContext.isResolvedBySyncHooks) {

--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -384,6 +384,33 @@ function urlToFilename(url) {
   return url;
 }
 
+/**
+ * Get the file path from a file: URL string, stripping search and hash params.
+ * Returns null if the input is not a valid file: URL or cannot be converted.
+ * @param {string} url
+ * @returns {string|null}
+ */
+function getFilePathFromFileURL(url) {
+  let parsedURL;
+  try {
+    parsedURL = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsedURL.protocol !== 'file:') {
+    return null;
+  }
+  if (parsedURL.search !== '' || parsedURL.hash !== '') {
+    parsedURL.search = '';
+    parsedURL.hash = '';
+  }
+  try {
+    return fileURLToPath(parsedURL);
+  } catch {
+    return null;
+  }
+}
+
 // Whether we have started executing any user-provided CJS code.
 // This is set right before we call the wrapped CJS code (not after,
 // in case we are half-way in the execution when internals check this).
@@ -561,4 +588,5 @@ module.exports = {
   },
   urlToFilename,
   getRequireStack,
+  getFilePathFromFileURL,
 };

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -353,8 +353,32 @@ function findPackageJSON(specifier, base = 'data:') {
   return pkg?.path;
 }
 
+/**
+ * Clear all package.json caches for a given package directory.
+ * This removes entries from:
+ * - The C++ native package_configs_ cache (via the binding)
+ * - The JS deserializedPackageJSONCache
+ * - The JS moduleToParentPackageJSONCache
+ * @param {string} packageJSONPath Absolute path to the package.json file.
+ */
+function clearPackageJSONCache(packageJSONPath) {
+  // Clear the native C++ cache.
+  modulesBinding.clearPackageJSONCache(packageJSONPath);
+
+  // Clear the JS-level deserialized cache.
+  deserializedPackageJSONCache.delete(packageJSONPath);
+
+  // Clear moduleToParentPackageJSONCache entries that point to this package.json.
+  for (const { 0: key, 1: value } of moduleToParentPackageJSONCache) {
+    if (value === packageJSONPath) {
+      moduleToParentPackageJSONCache.delete(key);
+    }
+  }
+}
+
 module.exports = {
   read,
+  clearPackageJSONCache,
   getNearestParentPackageJSON,
   getPackageScopeConfig,
   getPackageType,

--- a/lib/module.js
+++ b/lib/module.js
@@ -20,6 +20,7 @@ const {
   findPackageJSON,
 } = require('internal/modules/package_json_reader');
 const { stripTypeScriptTypes } = require('internal/modules/typescript');
+const { clearCache } = require('internal/modules/clear');
 
 Module.register = register;
 Module.constants = constants;
@@ -28,6 +29,7 @@ Module.findPackageJSON = findPackageJSON;
 Module.flushCompileCache = flushCompileCache;
 Module.getCompileCacheDir = getCompileCacheDir;
 Module.stripTypeScriptTypes = stripTypeScriptTypes;
+Module.clearCache = clearCache;
 
 // SourceMap APIs
 Module.findSourceMap = findSourceMap;

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -745,8 +745,8 @@ void ModuleWrap::Instantiate(const FunctionCallbackInfo<Value>& args) {
 
   {
     TryCatchScope try_catch(env);
-    USE(module->InstantiateModule(
-        context, ResolveModuleCallback, ResolveSourceCallback));
+    Maybe<bool> instantiated = module->InstantiateModule(
+        context, ResolveModuleCallback, ResolveSourceCallback);
 
     if (try_catch.HasCaught() && !try_catch.HasTerminated()) {
       CHECK(!try_catch.Message().IsEmpty());
@@ -758,7 +758,16 @@ void ModuleWrap::Instantiate(const FunctionCallbackInfo<Value>& args) {
       try_catch.ReThrow();
       return;
     }
+
+    if (instantiated.IsNothing() || !instantiated.FromJust()) {
+      return;
+    }
   }
+
+  // After instantiation, V8 holds the module graph. Drop the extra JS
+  // references to imported ModuleWraps so they can be collected once they
+  // are removed from Node.js caches.
+  args.This()->SetInternalField(kLinkedRequestsSlot, Undefined(isolate));
 }
 
 void ModuleWrap::Evaluate(const FunctionCallbackInfo<Value>& args) {

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -216,10 +216,10 @@ class ModuleWrap : public BaseObject {
   // nullopt value.
   std::optional<bool> has_async_graph_ = std::nullopt;
   int module_hash_;
-  // Corresponds to the ModuleWrap* of the wrappers in kLinkedRequestsSlot.
-  // These are populated during Link(), and are only valid after that as
-  // convenient shortcuts, but do not hold the ModuleWraps alive. The actual
-  // strong references come from the array in kLinkedRequestsSlot.
+  // Corresponds to the ModuleWrap* of the wrappers in kLinkedRequestsSlot
+  // during Link()/Instantiate(). These are convenient shortcuts and do not
+  // hold the ModuleWraps alive. The JS array in kLinkedRequestsSlot is
+  // cleared after successful instantiation.
   std::vector<ModuleWrap*> linked_module_wraps_;
 };
 

--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -608,6 +608,26 @@ void SaveCompileCacheEntry(const FunctionCallbackInfo<Value>& args) {
   env->compile_cache_handler()->MaybeSave(cache_entry, utf8.ToStringView());
 }
 
+void BindingData::ClearPackageJSONCache(
+    const FunctionCallbackInfo<Value>& args) {
+  CHECK_GE(args.Length(), 1);
+  CHECK(args[0]->IsString());
+
+  Realm* realm = Realm::GetCurrent(args);
+  auto binding_data = realm->GetBindingData<BindingData>();
+
+  BufferValue path(realm->isolate(), args[0]);
+  ToNamespacedPath(realm->env(), &path);
+
+  auto it = binding_data->package_configs_.find(path.ToString());
+  if (it != binding_data->package_configs_.end()) {
+    binding_data->package_configs_.erase(it);
+    args.GetReturnValue().Set(true);
+  } else {
+    args.GetReturnValue().Set(false);
+  }
+}
+
 void BindingData::CreatePerIsolateProperties(IsolateData* isolate_data,
                                              Local<ObjectTemplate> target) {
   Isolate* isolate = isolate_data->isolate();
@@ -628,6 +648,7 @@ void BindingData::CreatePerIsolateProperties(IsolateData* isolate_data,
   SetMethod(isolate, target, "flushCompileCache", FlushCompileCache);
   SetMethod(isolate, target, "getCompileCacheEntry", GetCompileCacheEntry);
   SetMethod(isolate, target, "saveCompileCacheEntry", SaveCompileCacheEntry);
+  SetMethod(isolate, target, "clearPackageJSONCache", ClearPackageJSONCache);
 }
 
 void BindingData::CreatePerContextProperties(Local<Object> target,
@@ -699,6 +720,7 @@ void BindingData::RegisterExternalReferences(
   registry->Register(FlushCompileCache);
   registry->Register(GetCompileCacheEntry);
   registry->Register(SaveCompileCacheEntry);
+  registry->Register(ClearPackageJSONCache);
 }
 
 }  // namespace modules

--- a/src/node_modules.h
+++ b/src/node_modules.h
@@ -64,6 +64,8 @@ class BindingData : public SnapshotableObject {
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetPackageJSONScripts(
       const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void ClearPackageJSONCache(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
 
   static void CreatePerIsolateProperties(IsolateData* isolate_data,
                                          v8::Local<v8::ObjectTemplate> ctor);

--- a/test/es-module/test-module-clear-cache-cross-system.mjs
+++ b/test/es-module/test-module-clear-cache-cross-system.mjs
@@ -1,0 +1,60 @@
+// Tests that clearCache clears caches across BOTH CJS and ESM,
+// regardless of which resolver is used.
+//
+// - resolver 'require' resolves via CJS → also clears ESM load cache
+// - resolver 'import'  resolves via ESM → also clears CJS Module._cache
+
+import '../common/index.mjs';
+
+import assert from 'node:assert';
+import { clearCache, createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const fixtureURL = new URL('../fixtures/module-cache/cjs-counter.js', import.meta.url);
+const fixturePath = fileURLToPath(fixtureURL);
+
+// --- Test 1: resolver 'require' also clears ESM load cache ---
+
+// Load via require.
+const cjs1 = require(fixturePath);
+assert.strictEqual(cjs1.count, 1);
+
+// Load via import — uses Module._cache entry, same count.
+const esm1 = await import(fixtureURL.href);
+assert.strictEqual(esm1.default.count, 1);
+
+// Clear with resolver: 'require'. This resolves to the filename, converts
+// to file URL, then clears Module._cache AND ESM load cache.
+clearCache(fixturePath, {
+  parentURL: import.meta.url,
+  resolver: 'require',
+});
+
+// CJS cache should be cleared.
+assert.strictEqual(require.cache[fixturePath], undefined);
+
+// ESM load cache should also be cleared — re-import must re-evaluate.
+const esm2 = await import(fixtureURL.href);
+assert.strictEqual(esm2.default.count, 2);
+
+// --- Test 2: resolver 'import' also clears CJS Module._cache ---
+
+// Ensure CJS cache is populated (import above already did this via translator).
+assert.notStrictEqual(require.cache[fixturePath], undefined);
+
+// Clear with resolver: 'import'. This resolves to a file URL, extracts
+// the file path, then clears both ESM and CJS caches.
+clearCache(fixtureURL, {
+  parentURL: import.meta.url,
+  resolver: 'import',
+});
+
+// CJS cache must be cleared even though we used the 'import' resolver.
+assert.strictEqual(require.cache[fixturePath], undefined);
+
+// Re-require must re-evaluate.
+const cjs3 = require(fixturePath);
+assert.strictEqual(cjs3.count, 3);
+
+delete globalThis.__module_cache_cjs_counter;

--- a/test/es-module/test-module-clear-cache-hash-map.mjs
+++ b/test/es-module/test-module-clear-cache-hash-map.mjs
@@ -1,0 +1,112 @@
+// Flags: --expose-internals
+// Evaluates the hash_to_module_map memory behaviour across clearCache cycles.
+//
+// hash_to_module_map is a C++ unordered_multimap<int, ModuleWrap*> on the
+// Environment. Every new ModuleWrap adds an entry; the destructor removes it.
+// Clearing the Node-side loadCache does not directly touch hash_to_module_map —
+// entries are removed only when ModuleWrap objects are garbage-collected.
+//
+// We verify two invariants:
+//
+//  1. DYNAMIC imports: after clearCache + GC, the old ModuleWrap is collected
+//     and therefore its hash_to_module_map entry is removed. The map does NOT
+//     grow without bound for purely-dynamic import/clear cycles.
+//     (Verified via checkIfCollectableByCounting.)
+//
+//  2. STATIC imports: when a parent P statically imports M, clearing M from
+//     the load cache does not free M's ModuleWrap (the static link keeps it).
+//     Each re-import adds one new entry while the old entry stays for the
+//     lifetime of P. This is a bounded, expected retention (not an unbounded
+//     leak): it is capped at one stale entry per module per live static parent.
+
+import '../common/index.mjs';
+
+import assert from 'node:assert';
+import { clearCache, createRequire } from 'node:module';
+import { queryObjects } from 'v8';
+
+const require = createRequire(import.meta.url);
+const { checkIfCollectableByCounting } = require('../common/gc');
+const { internalBinding } = require('internal/test/binding');
+const { ModuleWrap } = internalBinding('module_wrap');
+
+const counterBase = new URL(
+  '../fixtures/module-cache/esm-counter.mjs',
+  import.meta.url,
+).href;
+
+const parentURL = new URL(
+  '../fixtures/module-cache/esm-static-parent.mjs',
+  import.meta.url,
+).href;
+
+// ── Invariant 1: dynamic-only cycles do NOT leak ModuleWraps ────────────────
+// Use cache-busting query params so each import gets a distinct URL.
+
+const outer = 8;
+const inner = 4;
+
+await checkIfCollectableByCounting(async (i) => {
+  for (let j = 0; j < inner; j++) {
+    const url = `${counterBase}?hm=${i}-${j}`;
+    await import(url);
+    clearCache(url, {
+      parentURL: import.meta.url,
+      resolver: 'import',
+    });
+  }
+  return inner;
+}, ModuleWrap, outer, 50);
+
+// ── Invariant 2: static-parent cycles cause bounded retention ───────────────
+// After loading the static parent (which pins one counter instance), each
+// clear+re-import of the base counter URL creates exactly one new ModuleWrap
+// while the old one stays alive (pinned by the parent).
+// The net growth per cycle is +1. After N cycles the live count is
+//   baseline + 1(parent) + 1(pinned original counter) + 1(current counter)
+// — a constant overhead, not growing with N.
+
+// Load the static parent; this also loads the counter (count starts at 1 for
+// the global, but we seed it fresh by clearing any earlier runs' state).
+delete globalThis.__module_cache_esm_counter;
+
+const parent = await import(parentURL);
+assert.strictEqual(parent.count, 1);
+
+const wrapCount0 = queryObjects(ModuleWrap, { format: 'count' });
+
+// Cycle 1: clear counter + re-import → new instance created, old pinned.
+clearCache(counterBase, {
+  parentURL: import.meta.url,
+  resolver: 'import',
+});
+const v2 = await import(counterBase);
+assert.strictEqual(v2.count, 2);
+
+const wrapCount1 = queryObjects(ModuleWrap, { format: 'count' });
+// +1 new ModuleWrap (v2); old one kept alive by parent's static link.
+assert.strictEqual(wrapCount1, wrapCount0 + 1,
+                   'Each clear+reimport cycle adds exactly one new ModuleWrap ' +
+                   'when a static parent holds the old instance');
+
+// Cycle 2: clear counter again + re-import.
+clearCache(counterBase, {
+  parentURL: import.meta.url,
+  resolver: 'import',
+});
+const v3 = await import(counterBase);
+assert.strictEqual(v3.count, 3);
+
+const wrapCount2 = queryObjects(ModuleWrap, { format: 'count' });
+// Another +1 (v3); v2 is no longer in loadCache and has no other strong
+// holder, so it MAY have been collected already. v1 (pinned by parent) is
+// still alive. Net growth is bounded by the number of active versions in
+// any live strong reference — typically just the current one plus the
+// parent-pinned original.
+assert.ok(
+  wrapCount2 <= wrapCount1 + 1,
+  `After a second cycle, live ModuleWrap count should grow by at most 1 ` +
+  `(got ${wrapCount2}, was ${wrapCount1})`,
+);
+
+delete globalThis.__module_cache_esm_counter;

--- a/test/es-module/test-module-clear-cache-hash-map.mjs
+++ b/test/es-module/test-module-clear-cache-hash-map.mjs
@@ -1,23 +1,27 @@
 // Flags: --expose-internals
-// Evaluates the hash_to_module_map memory behaviour across clearCache cycles.
+// Evaluates internal book-keeping memory behaviour across clearCache cycles.
 //
-// hash_to_module_map is a C++ unordered_multimap<int, ModuleWrap*> on the
-// Environment. Every new ModuleWrap adds an entry; the destructor removes it.
-// Clearing the Node-side loadCache does not directly touch hash_to_module_map —
-// entries are removed only when ModuleWrap objects are garbage-collected.
+// Node.js keeps internal book-keeping for compiled ES modules so that a
+// compiled module can be looked up again while it is still alive. Entries are
+// added when a module is compiled and removed when that module is
+// garbage-collected. Clearing the Node-side load cache does not directly
+// touch this book-keeping — entries go away only when the corresponding
+// module objects are collected.
 //
 // We verify two invariants:
 //
-//  1. DYNAMIC imports: after clearCache + GC, the old ModuleWrap is collected
-//     and therefore its hash_to_module_map entry is removed. The map does NOT
-//     grow without bound for purely-dynamic import/clear cycles.
+//  1. DYNAMIC imports: after clearCache + GC, the old compiled module is
+//     collected and therefore its internal book-keeping entry is removed.
+//     Book-keeping does NOT grow without bound for purely-dynamic
+//     import/clear cycles.
 //     (Verified via checkIfCollectableByCounting.)
 //
 //  2. STATIC imports: when a parent P statically imports M, clearing M from
-//     the load cache does not free M's ModuleWrap (the static link keeps it).
-//     Each re-import adds one new entry while the old entry stays for the
-//     lifetime of P. This is a bounded, expected retention (not an unbounded
-//     leak): it is capped at one stale entry per module per live static parent.
+//     the load cache does not free M's compiled module (the static link
+//     keeps it). Each re-import adds one new entry while the old entry stays
+//     for the lifetime of P. This is a bounded, expected retention (not an
+//     unbounded leak): it is capped at one stale entry per module per live
+//     static parent.
 
 import '../common/index.mjs';
 
@@ -40,7 +44,7 @@ const parentURL = new URL(
   import.meta.url,
 ).href;
 
-// ── Invariant 1: dynamic-only cycles do NOT leak ModuleWraps ────────────────
+// ── Invariant 1: dynamic-only cycles do NOT leak compiled modules ───────────
 // Use cache-busting query params so each import gets a distinct URL.
 
 const outer = 8;
@@ -60,8 +64,8 @@ await checkIfCollectableByCounting(async (i) => {
 
 // ── Invariant 2: static-parent cycles cause bounded retention ───────────────
 // After loading the static parent (which pins one counter instance), each
-// clear+re-import of the base counter URL creates exactly one new ModuleWrap
-// while the old one stays alive (pinned by the parent).
+// clear+re-import of the base counter URL creates exactly one new compiled
+// module while the old one stays alive (pinned by the parent).
 // The net growth per cycle is +1. After N cycles the live count is
 //   baseline + 1(parent) + 1(pinned original counter) + 1(current counter)
 // — a constant overhead, not growing with N.
@@ -84,10 +88,10 @@ const v2 = await import(counterBase);
 assert.strictEqual(v2.count, 2);
 
 const wrapCount1 = queryObjects(ModuleWrap, { format: 'count' });
-// +1 new ModuleWrap (v2); old one kept alive by parent's static link.
+// +1 new compiled module (v2); old one kept alive by parent's static link.
 assert.strictEqual(wrapCount1, wrapCount0 + 1,
-                   'Each clear+reimport cycle adds exactly one new ModuleWrap ' +
-                   'when a static parent holds the old instance');
+                   'Each clear+reimport cycle adds exactly one new compiled ' +
+                   'module when a static parent holds the old instance');
 
 // Cycle 2: clear counter again + re-import.
 clearCache(counterBase, {
@@ -98,14 +102,14 @@ const v3 = await import(counterBase);
 assert.strictEqual(v3.count, 3);
 
 const wrapCount2 = queryObjects(ModuleWrap, { format: 'count' });
-// Another +1 (v3); v2 is no longer in loadCache and has no other strong
+// Another +1 (v3); v2 is no longer in the load cache and has no other strong
 // holder, so it MAY have been collected already. v1 (pinned by parent) is
 // still alive. Net growth is bounded by the number of active versions in
 // any live strong reference — typically just the current one plus the
 // parent-pinned original.
 assert.ok(
   wrapCount2 <= wrapCount1 + 1,
-  `After a second cycle, live ModuleWrap count should grow by at most 1 ` +
+  `After a second cycle, live compiled-module count should grow by at most 1 ` +
   `(got ${wrapCount2}, was ${wrapCount1})`,
 );
 

--- a/test/es-module/test-module-clear-cache-import-cjs-race.mjs
+++ b/test/es-module/test-module-clear-cache-import-cjs-race.mjs
@@ -1,0 +1,89 @@
+// Tests race conditions between clearCache and concurrent dynamic imports
+// of a CJS module loaded via import().
+//
+// Scenarios covered:
+//   A) clearCache fires BEFORE the in-flight import promise settles:
+//        p = import(url); clearCache(url); result = await p
+//      The original import must still succeed with the first module instance.
+//
+//   B) Two concurrent imports (sharing the same in-flight job) with clearCache
+//      between them, then a third import after clearing:
+//        p1 = import(url)          → job1 created, cached
+//        p2 = import(url)          → reuses job1 (same in-flight promise)
+//        clearCache(url)           → removes job1 from cache
+//        p3 = import(url)          → job3 created (fresh execution)
+//        [await all three]
+//      p1 and p2 must resolve to the SAME module instance (they shared job1).
+//      p3 must resolve to a DIFFERENT, freshly-executed module instance.
+//
+//   C) clearCache fires AFTER the import has fully settled and another clear +
+//      import is done serially — basic sanity check that repeated cycles work.
+
+import '../common/index.mjs';
+import assert from 'node:assert';
+import { clearCache } from 'node:module';
+
+const url = new URL('../fixtures/module-cache/cjs-counter.js', import.meta.url);
+
+// ── Scenario A: clearCache before in-flight import settles ──────────────────
+
+const p_a = import(url.href);  // in-flight; module not yet resolved
+clearCache(url, {
+  parentURL: import.meta.url,
+  resolver: 'import',
+});
+
+const result_a = await p_a;
+// Scenario A: in-flight import must still resolve to the first instance.
+assert.strictEqual(result_a.default.count, 1);
+
+// ── Scenario B: two concurrent imports share a job; clearCache between ──────
+
+// Re-seed for a clean counter baseline.
+clearCache(url, {
+  parentURL: import.meta.url,
+  resolver: 'import',
+});
+
+delete globalThis.__module_cache_cjs_counter;
+
+// Both p_b1 and p_b2 start before clearCache → they share the same in-flight job.
+const p_b1 = import(url.href);
+const p_b2 = import(url.href);
+
+clearCache(url, {
+  parentURL: import.meta.url,
+  resolver: 'import',
+});
+
+// p_b3 starts after clearCache → gets a fresh independent job.
+const p_b3 = import(url.href);
+
+const [r_b1, r_b2, r_b3] = await Promise.all([p_b1, p_b2, p_b3]);
+
+// p_b1 and p_b2 shared the same in-flight job → identical module namespace.
+assert.strictEqual(r_b1, r_b2);
+// Scenario B: shared job resolves to the first (re-seeded) instance.
+assert.strictEqual(r_b1.default.count, 1);
+
+// p_b3 was created after clearCache → fresh execution, different instance.
+assert.notStrictEqual(r_b3, r_b1);
+assert.strictEqual(r_b3.default.count, 2);
+
+// ── Scenario C: serial repeated cycles ─────────────────────────────────────
+
+clearCache(url, {
+  parentURL: import.meta.url,
+  resolver: 'import',
+});
+const r_c1 = await import(url.href);
+assert.strictEqual(r_c1.default.count, 3);
+
+clearCache(url, {
+  parentURL: import.meta.url,
+  resolver: 'import',
+});
+const r_c2 = await import(url.href);
+assert.strictEqual(r_c2.default.count, 4);
+
+delete globalThis.__module_cache_cjs_counter;

--- a/test/es-module/test-module-clear-cache-query-variants.mjs
+++ b/test/es-module/test-module-clear-cache-query-variants.mjs
@@ -1,0 +1,21 @@
+import '../common/index.mjs';
+
+import assert from 'node:assert';
+import { clearCache } from 'node:module';
+
+const url = new URL('../fixtures/module-cache/esm-query-counter.mjs', import.meta.url);
+
+const first = await import(`${url.href}?v=1`);
+const second = await import(`${url.href}?v=2`);
+assert.strictEqual(first.count, 1);
+assert.strictEqual(second.count, 2);
+
+clearCache(url, {
+  parentURL: import.meta.url,
+  resolver: 'import',
+});
+
+const third = await import(`${url.href}?v=1`);
+assert.strictEqual(third.count, 3);
+
+delete globalThis.__module_cache_esm_query_counter;

--- a/test/es-module/test-module-clear-cache-static-import-leak.mjs
+++ b/test/es-module/test-module-clear-cache-static-import-leak.mjs
@@ -1,0 +1,104 @@
+// Flags: --expose-internals
+// Verifies the V8-level memory-retention behaviour of clearCache when a module
+// is statically imported by a still-live parent.
+//
+// BACKGROUND:
+//   When a parent module P statically imports M (via `import … from './M'`),
+//   V8's module instantiation creates an internal strong reference from P's
+//   compiled module record to M's module record.  This link is permanent for
+//   the lifetime of P.  Clearing M from Node.js's JS-level caches (loadCache /
+//   resolveCache) does NOT sever the V8-internal link; the old ModuleWrap for
+//   M stays alive as long as P is alive.
+//
+//   Consequence:  after `clearCache(M)` + `await import(M)`, TWO module
+//   instances coexist:
+//     - M_old : retained by P's V8-internal link, never re-executed by P
+//     - M_new : created by the fresh import(), seen by all NEW importers
+//
+//   This is a *bounded* leak (one stale instance per cleared module per live
+//   static parent), not an unbounded one.  It is unavoidable given the
+//   ECMA-262 HostLoadImportedModule idempotency requirement.
+//
+//   For purely dynamic imports (no static parent holding them) the old
+//   ModuleWrap IS collectible after clearCache — see the second half of this
+//   test which uses checkIfCollectableByCounting to confirm that.
+
+import '../common/index.mjs';
+
+import assert from 'node:assert';
+import { clearCache, createRequire } from 'node:module';
+import { queryObjects } from 'v8';
+
+// Use createRequire to access CJS-only internals from this ESM file.
+const require = createRequire(import.meta.url);
+const { checkIfCollectableByCounting } = require('../common/gc');
+const { internalBinding } = require('internal/test/binding');
+const { ModuleWrap } = internalBinding('module_wrap');
+
+const counterURL = new URL(
+  '../fixtures/module-cache/esm-counter.mjs',
+  import.meta.url,
+).href;
+
+const parentURL = new URL(
+  '../fixtures/module-cache/esm-static-parent.mjs',
+  import.meta.url,
+).href;
+
+// ── Part 1 : static-parent split-brain ──────────────────────────────────────
+// Load the static parent, which in turn statically imports esm-counter.mjs.
+
+const parent = await import(parentURL);
+assert.strictEqual(parent.count, 1);  // counter runs once
+
+// Snapshot the number of live ModuleWraps before clearing.
+const wrapsBefore = queryObjects(ModuleWrap, { format: 'count' });
+
+// Clear the counter's Node-side caches (does NOT sever V8 static links).
+clearCache(counterURL, {
+  parentURL: import.meta.url,
+  resolver: 'import',
+});
+
+// Re-import counter: a fresh instance is created and executed.
+const fresh = await import(counterURL);
+assert.strictEqual(fresh.count, 2);   // New execution.
+// Parent still sees the OLD instance via the V8-internal static link —
+// the "split-brain" behaviour.
+assert.strictEqual(parent.count, 1);
+
+// After the fresh import there should be MORE live ModuleWraps than before,
+// because the old instance (held by the parent) was NOT collected.
+const wrapsAfter = queryObjects(ModuleWrap, { format: 'count' });
+assert.ok(
+  wrapsAfter > wrapsBefore,
+  `Expected more live ModuleWraps after re-import (old instance retained ` +
+  `by static parent).  before=${wrapsBefore}, after=${wrapsAfter}`,
+);
+
+// ── Part 2 : dynamic-only modules ARE collectible ───────────────────────────
+// Prove that for purely-dynamic imports (no static parent), cleared modules
+// can be garbage-collected.  This confirms that the static-parent case is the
+// source of the memory retention, not clearCache itself.
+
+const baseURL = new URL(
+  '../fixtures/module-cache/esm-counter.mjs',
+  import.meta.url,
+).href;
+
+const outer = 8;
+const inner = 4;
+
+await checkIfCollectableByCounting(async (i) => {
+  for (let j = 0; j < inner; j++) {
+    const url = `${baseURL}?leak-test=${i}-${j}`;
+    await import(url);
+    clearCache(url, {
+      parentURL: import.meta.url,
+      resolver: 'import',
+    });
+  }
+  return inner;
+}, ModuleWrap, outer, 50);
+
+delete globalThis.__module_cache_esm_counter;

--- a/test/es-module/test-module-clear-cache-wasm-leak.mjs
+++ b/test/es-module/test-module-clear-cache-wasm-leak.mjs
@@ -1,0 +1,29 @@
+// Flags: --no-warnings
+
+import { mustCall, mustCallAtLeast } from '../common/index.mjs';
+import assert from 'node:assert';
+import { clearCache, createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { checkIfCollectableByCounting } = require('../common/gc');
+
+const baseUrl = new URL('../fixtures/simple.wasm', import.meta.url);
+
+const outer = 8;
+const inner = 4;
+
+const runIteration = mustCallAtLeast(async (i) => {
+  for (let j = 0; j < inner; j++) {
+    const url = new URL(baseUrl);
+    url.search = `?v=${i}-${j}`;
+    const mod = await import(url.href);
+    assert.strictEqual(mod.add(1, 2), 3);
+    clearCache(url, {
+      parentURL: import.meta.url,
+      resolver: 'import',
+    });
+  }
+  return inner;
+});
+
+checkIfCollectableByCounting(runIteration, WebAssembly.Instance, outer).then(mustCall());

--- a/test/es-module/test-module-clear-cache-wasm.mjs
+++ b/test/es-module/test-module-clear-cache-wasm.mjs
@@ -1,0 +1,19 @@
+// Flags: --no-warnings
+
+import '../common/index.mjs';
+import assert from 'node:assert';
+import { clearCache } from 'node:module';
+
+const url = new URL('../fixtures/simple.wasm', import.meta.url);
+
+const first = await import(url.href);
+assert.strictEqual(first.add(1, 2), 3);
+
+clearCache(url, {
+  parentURL: import.meta.url,
+  resolver: 'import',
+});
+
+const second = await import(url.href);
+assert.strictEqual(second.add(2, 3), 5);
+assert.notStrictEqual(first, second);

--- a/test/es-module/test-module-clear-cache.mjs
+++ b/test/es-module/test-module-clear-cache.mjs
@@ -1,0 +1,38 @@
+import '../common/index.mjs';
+
+import assert from 'node:assert';
+import { clearCache } from 'node:module';
+
+const specifier = '../fixtures/module-cache/esm-counter.mjs';
+
+const first = await import(specifier);
+const second = await import(specifier);
+
+assert.strictEqual(first.count, 1);
+assert.strictEqual(second.count, 1);
+assert.strictEqual(first, second);
+
+clearCache(specifier, {
+  parentURL: import.meta.url,
+  resolver: 'import',
+});
+
+const third = await import(specifier);
+assert.strictEqual(third.count, 2);
+
+const nested = new URL('../fixtures/module-cache/esm-nested-a.mjs', import.meta.url);
+const nestedFirst = await import(`${nested.href}?v=1`);
+assert.strictEqual(nestedFirst.value, 1);
+
+clearCache(new URL('../fixtures/module-cache/esm-nested-b.mjs', import.meta.url), {
+  parentURL: import.meta.url,
+  resolver: 'import',
+});
+
+const nestedSecond = await import(`${nested.href}?v=2`);
+assert.strictEqual(nestedSecond.value, 2);
+assert.strictEqual(globalThis.__module_cache_esm_nested_c_counter, 1);
+
+delete globalThis.__module_cache_esm_counter;
+delete globalThis.__module_cache_esm_nested_b_counter;
+delete globalThis.__module_cache_esm_nested_c_counter;

--- a/test/fixtures/module-cache/cjs-child.js
+++ b/test/fixtures/module-cache/cjs-child.js
@@ -1,0 +1,6 @@
+globalThis.__module_cache_cjs_child_counter =
+  (globalThis.__module_cache_cjs_child_counter ?? 0) + 1;
+
+module.exports = {
+  count: globalThis.__module_cache_cjs_child_counter,
+};

--- a/test/fixtures/module-cache/cjs-counter.js
+++ b/test/fixtures/module-cache/cjs-counter.js
@@ -1,0 +1,5 @@
+globalThis.__module_cache_cjs_counter = (globalThis.__module_cache_cjs_counter ?? 0) + 1;
+
+module.exports = {
+  count: globalThis.__module_cache_cjs_counter,
+};

--- a/test/fixtures/module-cache/cjs-parent.js
+++ b/test/fixtures/module-cache/cjs-parent.js
@@ -1,0 +1,5 @@
+const child = require('./cjs-child.js');
+
+module.exports = {
+  child,
+};

--- a/test/fixtures/module-cache/esm-counter.mjs
+++ b/test/fixtures/module-cache/esm-counter.mjs
@@ -1,0 +1,4 @@
+globalThis.__module_cache_esm_counter = (globalThis.__module_cache_esm_counter ?? 0) + 1;
+
+export const count = globalThis.__module_cache_esm_counter;
+export default count;

--- a/test/fixtures/module-cache/esm-nested-a.mjs
+++ b/test/fixtures/module-cache/esm-nested-a.mjs
@@ -1,0 +1,3 @@
+import { value } from './esm-nested-b.mjs';
+
+export { value };

--- a/test/fixtures/module-cache/esm-nested-b.mjs
+++ b/test/fixtures/module-cache/esm-nested-b.mjs
@@ -1,0 +1,6 @@
+import './esm-nested-c.mjs';
+
+globalThis.__module_cache_esm_nested_b_counter =
+  (globalThis.__module_cache_esm_nested_b_counter ?? 0) + 1;
+
+export const value = globalThis.__module_cache_esm_nested_b_counter;

--- a/test/fixtures/module-cache/esm-nested-c.mjs
+++ b/test/fixtures/module-cache/esm-nested-c.mjs
@@ -1,0 +1,4 @@
+globalThis.__module_cache_esm_nested_c_counter =
+  (globalThis.__module_cache_esm_nested_c_counter ?? 0) + 1;
+
+export const count = globalThis.__module_cache_esm_nested_c_counter;

--- a/test/fixtures/module-cache/esm-query-counter.mjs
+++ b/test/fixtures/module-cache/esm-query-counter.mjs
@@ -1,0 +1,4 @@
+globalThis.__module_cache_esm_query_counter =
+  (globalThis.__module_cache_esm_query_counter ?? 0) + 1;
+
+export const count = globalThis.__module_cache_esm_query_counter;

--- a/test/fixtures/module-cache/esm-static-parent.mjs
+++ b/test/fixtures/module-cache/esm-static-parent.mjs
@@ -1,0 +1,3 @@
+// A parent module that statically imports esm-counter.mjs.
+// Used by tests that verify memory retention of statically-linked modules.
+export { count } from './esm-counter.mjs';

--- a/test/fixtures/source-map/cjs-closure-source-map.js
+++ b/test/fixtures/source-map/cjs-closure-source-map.js
@@ -1,0 +1,9 @@
+function crash() {
+  throw new Error('boom');
+}
+
+module.exports = {
+  crash,
+};
+
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNqcy1jbG9zdXJlLXNvdXJjZS1tYXAtb3JpZ2luYWwuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEiLCJzb3VyY2VzQ29udGVudCI6WyJmdW5jdGlvbiBjcmFzaCgpIHtcbiAgdGhyb3cgbmV3IEVycm9yKCdib29tJyk7XG59XG4iXX0=

--- a/test/module-hooks/test-module-hooks-clear-cache-import-attributes.js
+++ b/test/module-hooks/test-module-hooks-clear-cache-import-attributes.js
@@ -1,0 +1,80 @@
+// Flags: --expose-internals
+// Tests that the importAttributes option is forwarded correctly
+// to the ESM resolve cache deletion.
+'use strict';
+
+const common = require('../common');
+
+const assert = require('node:assert');
+const { pathToFileURL } = require('node:url');
+const { clearCache, registerHooks } = require('node:module');
+const { getOrInitializeCascadedLoader } = require('internal/modules/esm/loader');
+
+const hook = registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier === 'virtual-json') {
+      return {
+        url: 'virtual://json-data',
+        format: 'json',
+        shortCircuit: true,
+      };
+    }
+    return nextResolve(specifier, context);
+  },
+  load(url, context, nextLoad) {
+    if (url === 'virtual://json-data') {
+      return {
+        format: 'json',
+        source: '{"key": "value"}',
+        shortCircuit: true,
+      };
+    }
+    return nextLoad(url, context);
+  },
+});
+
+(async () => {
+  const first = await import('virtual-json', { with: { type: 'json' } });
+  assert.deepStrictEqual(first.default, { key: 'value' });
+
+  const cascadedLoader = getOrInitializeCascadedLoader();
+  const capturedCalls = [];
+  const original = cascadedLoader.deleteResolveCacheEntry;
+  cascadedLoader.deleteResolveCacheEntry = function(specifier, parentURL, importAttributes) {
+    capturedCalls.push({ specifier, parentURL, importAttributes });
+    return original.call(this, specifier, parentURL, importAttributes);
+  };
+
+  try {
+    // Without importAttributes — default empty object is forwarded.
+    clearCache('virtual-json', {
+      parentURL: pathToFileURL(__filename),
+      resolver: 'import',
+    });
+    assert.strictEqual(capturedCalls.length, 1);
+    assert.strictEqual(capturedCalls[0].specifier, 'virtual-json');
+    assert.deepStrictEqual(Object.keys(capturedCalls[0].importAttributes), []);
+
+    // With importAttributes: { type: 'json' } — forwarded through.
+    clearCache('virtual-json', {
+      parentURL: pathToFileURL(__filename),
+      resolver: 'import',
+      importAttributes: { type: 'json' },
+    });
+    assert.strictEqual(capturedCalls.length, 2);
+    assert.deepStrictEqual(capturedCalls[1].importAttributes, { type: 'json' });
+
+    // resolver: 'require' should NOT call deleteResolveCacheEntry
+    // even though clearCache still clears the CommonJS-side caches.
+    clearCache('virtual-json', {
+      parentURL: pathToFileURL(__filename),
+      resolver: 'require',
+      importAttributes: { type: 'json' },
+    });
+    assert.strictEqual(capturedCalls.length, 2);
+  } finally {
+    cascadedLoader.deleteResolveCacheEntry = original;
+  }
+
+  hook.deregister();
+})().then(common.mustCall());

--- a/test/module-hooks/test-module-hooks-clear-cache-import-attributes.js
+++ b/test/module-hooks/test-module-hooks-clear-cache-import-attributes.js
@@ -1,6 +1,6 @@
-// Flags: --expose-internals
-// Tests that the importAttributes option is forwarded correctly
-// to the ESM resolve cache deletion.
+// Tests that clearCache with importAttributes reloads a module imported
+// with matching attributes, and that resolver: 'require' is a no-op that
+// does not throw.
 'use strict';
 
 const common = require('../common');
@@ -8,8 +8,8 @@ const common = require('../common');
 const assert = require('node:assert');
 const { pathToFileURL } = require('node:url');
 const { clearCache, registerHooks } = require('node:module');
-const { getOrInitializeCascadedLoader } = require('internal/modules/esm/loader');
 
+let loadCalls = 0;
 const hook = registerHooks({
   resolve(specifier, context, nextResolve) {
     if (specifier === 'virtual-json') {
@@ -23,6 +23,7 @@ const hook = registerHooks({
   },
   load(url, context, nextLoad) {
     if (url === 'virtual://json-data') {
+      loadCalls++;
       return {
         format: 'json',
         source: '{"key": "value"}',
@@ -36,45 +37,25 @@ const hook = registerHooks({
 (async () => {
   const first = await import('virtual-json', { with: { type: 'json' } });
   assert.deepStrictEqual(first.default, { key: 'value' });
+  assert.strictEqual(loadCalls, 1);
 
-  const cascadedLoader = getOrInitializeCascadedLoader();
-  const capturedCalls = [];
-  const original = cascadedLoader.deleteResolveCacheEntry;
-  cascadedLoader.deleteResolveCacheEntry = function(specifier, parentURL, importAttributes) {
-    capturedCalls.push({ specifier, parentURL, importAttributes });
-    return original.call(this, specifier, parentURL, importAttributes);
-  };
+  // Matching importAttributes: the next import must load again.
+  clearCache('virtual-json', {
+    parentURL: pathToFileURL(__filename),
+    resolver: 'import',
+    importAttributes: { type: 'json' },
+  });
 
-  try {
-    // Without importAttributes — default empty object is forwarded.
-    clearCache('virtual-json', {
-      parentURL: pathToFileURL(__filename),
-      resolver: 'import',
-    });
-    assert.strictEqual(capturedCalls.length, 1);
-    assert.strictEqual(capturedCalls[0].specifier, 'virtual-json');
-    assert.deepStrictEqual(Object.keys(capturedCalls[0].importAttributes), []);
+  const second = await import('virtual-json', { with: { type: 'json' } });
+  assert.deepStrictEqual(second.default, { key: 'value' });
+  assert.strictEqual(loadCalls, 2);
 
-    // With importAttributes: { type: 'json' } — forwarded through.
-    clearCache('virtual-json', {
-      parentURL: pathToFileURL(__filename),
-      resolver: 'import',
-      importAttributes: { type: 'json' },
-    });
-    assert.strictEqual(capturedCalls.length, 2);
-    assert.deepStrictEqual(capturedCalls[1].importAttributes, { type: 'json' });
-
-    // resolver: 'require' should NOT call deleteResolveCacheEntry
-    // even though clearCache still clears the CommonJS-side caches.
-    clearCache('virtual-json', {
-      parentURL: pathToFileURL(__filename),
-      resolver: 'require',
-      importAttributes: { type: 'json' },
-    });
-    assert.strictEqual(capturedCalls.length, 2);
-  } finally {
-    cascadedLoader.deleteResolveCacheEntry = original;
-  }
+  // resolver: 'require' should not throw even when importAttributes are set.
+  clearCache('virtual-json', {
+    parentURL: pathToFileURL(__filename),
+    resolver: 'require',
+    importAttributes: { type: 'json' },
+  });
 
   hook.deregister();
 })().then(common.mustCall());

--- a/test/module-hooks/test-module-hooks-clear-cache-redirect.js
+++ b/test/module-hooks/test-module-hooks-clear-cache-redirect.js
@@ -1,0 +1,55 @@
+'use strict';
+
+// Tests that clearCache with resolver: 'import' respects registered hooks
+// that redirect specifiers. When a hook redirects specifier A to specifier B,
+// clearCache(A) should clear the cache for B (the redirected target).
+
+const common = require('../common');
+
+const assert = require('node:assert');
+const { pathToFileURL } = require('node:url');
+const { clearCache, registerHooks } = require('node:module');
+
+const hook = registerHooks({
+  resolve(specifier, context, nextResolve) {
+    // Redirect 'redirected-esm' to a virtual URL.
+    if (specifier === 'redirected-esm') {
+      return {
+        url: 'virtual://redirected-target',
+        format: 'module',
+        shortCircuit: true,
+      };
+    }
+    return nextResolve(specifier, context);
+  },
+  load(url, context, nextLoad) {
+    if (url === 'virtual://redirected-target') {
+      return {
+        format: 'module',
+        source: 'globalThis.__module_cache_redirect_counter = ' +
+          '(globalThis.__module_cache_redirect_counter ?? 0) + 1;\n' +
+          'export const count = globalThis.__module_cache_redirect_counter;\n',
+        shortCircuit: true,
+      };
+    }
+    return nextLoad(url, context);
+  },
+});
+
+(async () => {
+  const first = await import('redirected-esm');
+  assert.strictEqual(first.count, 1);
+
+  // Clear using the original specifier — hooks should resolve it
+  // to the redirected target and clear that cache.
+  clearCache('redirected-esm', {
+    parentURL: pathToFileURL(__filename),
+    resolver: 'import',
+  });
+
+  const second = await import('redirected-esm');
+  assert.strictEqual(second.count, 2);
+
+  hook.deregister();
+  delete globalThis.__module_cache_redirect_counter;
+})().then(common.mustCall());

--- a/test/module-hooks/test-module-hooks-clear-cache-resolve-cache.js
+++ b/test/module-hooks/test-module-hooks-clear-cache-resolve-cache.js
@@ -1,0 +1,38 @@
+// Flags: --expose-internals
+// Tests that clearCache clears the ESM resolve cache and re-evaluates the
+// module on the next import.
+'use strict';
+
+const common = require('../common');
+
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+const { clearCache } = require('node:module');
+const { getOrInitializeCascadedLoader } = require('internal/modules/esm/loader');
+
+const fixture = path.join(__dirname, '..', 'fixtures', 'module-cache', 'esm-counter.mjs');
+const specifier = pathToFileURL(fixture).href;
+const parentURL = pathToFileURL(__filename).href;
+
+(async () => {
+  const cascadedLoader = getOrInitializeCascadedLoader();
+
+  const first = await import(specifier);
+  assert.strictEqual(first.count, 1);
+  assert.ok(cascadedLoader.hasResolveCacheEntry(specifier, parentURL),
+            'resolve cache should have an entry after import');
+
+  clearCache(specifier, {
+    parentURL,
+    resolver: 'import',
+  });
+
+  assert.ok(!cascadedLoader.hasResolveCacheEntry(specifier, parentURL),
+            'resolve cache should be cleared by clearCache');
+
+  const second = await import(specifier);
+  assert.strictEqual(second.count, 2);
+
+  delete globalThis.__module_cache_esm_counter;
+})().then(common.mustCall());

--- a/test/module-hooks/test-module-hooks-clear-cache-resolve-cache.js
+++ b/test/module-hooks/test-module-hooks-clear-cache-resolve-cache.js
@@ -1,6 +1,5 @@
-// Flags: --expose-internals
-// Tests that clearCache clears the ESM resolve cache and re-evaluates the
-// module on the next import.
+// Tests that clearCache causes the next import to re-evaluate the module
+// when customization hooks are registered.
 'use strict';
 
 const common = require('../common');
@@ -8,31 +7,36 @@ const common = require('../common');
 const assert = require('node:assert');
 const path = require('node:path');
 const { pathToFileURL } = require('node:url');
-const { clearCache } = require('node:module');
-const { getOrInitializeCascadedLoader } = require('internal/modules/esm/loader');
+const { clearCache, registerHooks } = require('node:module');
 
 const fixture = path.join(__dirname, '..', 'fixtures', 'module-cache', 'esm-counter.mjs');
 const specifier = pathToFileURL(fixture).href;
 const parentURL = pathToFileURL(__filename).href;
 
-(async () => {
-  const cascadedLoader = getOrInitializeCascadedLoader();
+let loadCalls = 0;
+const hook = registerHooks({
+  load(url, context, nextLoad) {
+    if (url.split('?')[0] === specifier) {
+      loadCalls++;
+    }
+    return nextLoad(url, context);
+  },
+});
 
+(async () => {
   const first = await import(specifier);
   assert.strictEqual(first.count, 1);
-  assert.ok(cascadedLoader.hasResolveCacheEntry(specifier, parentURL),
-            'resolve cache should have an entry after import');
+  assert.strictEqual(loadCalls, 1);
 
   clearCache(specifier, {
     parentURL,
     resolver: 'import',
   });
 
-  assert.ok(!cascadedLoader.hasResolveCacheEntry(specifier, parentURL),
-            'resolve cache should be cleared by clearCache');
-
   const second = await import(specifier);
   assert.strictEqual(second.count, 2);
+  assert.strictEqual(loadCalls, 2);
 
+  hook.deregister();
   delete globalThis.__module_cache_esm_counter;
 })().then(common.mustCall());

--- a/test/module-hooks/test-module-hooks-clear-cache.js
+++ b/test/module-hooks/test-module-hooks-clear-cache.js
@@ -1,0 +1,49 @@
+'use strict';
+
+require('../common');
+
+const assert = require('node:assert');
+const { pathToFileURL } = require('node:url');
+const { clearCache, registerHooks } = require('node:module');
+
+let loadCalls = 0;
+const hook = registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier === 'virtual') {
+      return {
+        url: 'virtual://cache-clear',
+        format: 'commonjs',
+        shortCircuit: true,
+      };
+    }
+    return nextResolve(specifier, context);
+  },
+  load(url, context, nextLoad) {
+    if (url === 'virtual://cache-clear') {
+      loadCalls++;
+      return {
+        format: 'commonjs',
+        source: 'globalThis.__module_cache_virtual_counter = ' +
+          '(globalThis.__module_cache_virtual_counter ?? 0) + 1;' +
+          'module.exports = { count: globalThis.__module_cache_virtual_counter };',
+        shortCircuit: true,
+      };
+    }
+    return nextLoad(url, context);
+  },
+});
+
+const first = require('virtual');
+assert.strictEqual(first.count, 1);
+
+clearCache('virtual', {
+  parentURL: pathToFileURL(__filename),
+  resolver: 'require',
+});
+
+const second = require('virtual');
+assert.strictEqual(second.count, 2);
+assert.strictEqual(loadCalls, 2);
+
+hook.deregister();
+delete globalThis.__module_cache_virtual_counter;

--- a/test/parallel/test-module-clear-cache-children.js
+++ b/test/parallel/test-module-clear-cache-children.js
@@ -1,0 +1,30 @@
+'use strict';
+
+require('../common');
+
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+const { clearCache } = require('node:module');
+
+const parentPath = path.join(__dirname, '..', 'fixtures', 'module-cache', 'cjs-parent.js');
+const childPath = path.join(__dirname, '..', 'fixtures', 'module-cache', 'cjs-child.js');
+
+const parent = require(parentPath);
+assert.strictEqual(parent.child.count, 1);
+
+const parentModule = require.cache[parentPath];
+assert.ok(parentModule.children.some((child) => child.id === childPath));
+
+clearCache(childPath, {
+  parentURL: pathToFileURL(__filename),
+  resolver: 'require',
+});
+
+assert.strictEqual(require.cache[childPath], undefined);
+assert.ok(!parentModule.children.some((child) => child.id === childPath));
+
+const childReloaded = require(childPath);
+assert.strictEqual(childReloaded.count, 2);
+
+delete globalThis.__module_cache_cjs_child_counter;

--- a/test/parallel/test-module-clear-cache-cjs-cache.js
+++ b/test/parallel/test-module-clear-cache-cjs-cache.js
@@ -1,0 +1,39 @@
+// Flags: --expose-internals
+// Verifies that CJS Module instances created when a CommonJS file is loaded
+// via import() are garbage-collectible after clearCache. Uses
+// checkIfCollectableByCounting for a robust GC-level check rather than
+// asserting on internal cache state.
+'use strict';
+
+const common = require('../common');
+
+const { pathToFileURL } = require('node:url');
+const { clearCache } = require('node:module');
+const { Module } = require('internal/modules/cjs/loader');
+const { checkIfCollectableByCounting } = require('../common/gc');
+
+const fixtureURL = new URL(
+  '../fixtures/module-cache/cjs-counter.js',
+  pathToFileURL(__filename),
+);
+const parentURL = pathToFileURL(__filename).href;
+
+const outer = 8;
+const inner = 4;
+
+const runIteration = common.mustCallAtLeast(async (i) => {
+  for (let j = 0; j < inner; j++) {
+    const url = `${fixtureURL.href}?v=${i}-${j}`;
+    await import(url);
+    clearCache(url, {
+      parentURL,
+      resolver: 'import',
+    });
+  }
+  return inner;
+});
+
+checkIfCollectableByCounting(runIteration, Module, outer)
+  .then(common.mustCall(() => {
+    delete globalThis.__module_cache_cjs_counter;
+  }));

--- a/test/parallel/test-module-clear-cache-cjs-resolution.js
+++ b/test/parallel/test-module-clear-cache-cjs-resolution.js
@@ -1,0 +1,36 @@
+// Flags: --expose-internals
+// Tests that clearCache clears the CommonJS module cache and the related
+// resolution caches for the resolved filename.
+'use strict';
+
+require('../common');
+
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+const Module = require('node:module');
+const { clearCache } = require('node:module');
+
+const fixture = path.join(__dirname, '..', 'fixtures', 'module-cache', 'cjs-counter.js');
+
+require(fixture);
+assert.notStrictEqual(Module._cache[fixture], undefined);
+
+const hasPathCacheEntry = () =>
+  Object.keys(Module._pathCache).some((key) => Module._pathCache[key] === fixture);
+
+assert.ok(hasPathCacheEntry(), 'Module._pathCache should contain the fixture');
+
+clearCache(fixture, {
+  parentURL: pathToFileURL(__filename),
+  resolver: 'require',
+});
+
+assert.ok(!hasPathCacheEntry(),
+          'Module._pathCache should not contain the fixture after clearCache');
+assert.strictEqual(Module._cache[fixture], undefined);
+
+const reloaded = require(fixture);
+assert.strictEqual(reloaded.count, 2);
+
+delete globalThis.__module_cache_cjs_counter;

--- a/test/parallel/test-module-clear-cache-leak.js
+++ b/test/parallel/test-module-clear-cache-leak.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const common = require('../common');
+
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+const Module = require('node:module');
+const { clearCache } = require('node:module');
+const { checkIfCollectableByCounting } = require('../common/gc');
+
+const fixture = path.join(__dirname, '..', 'fixtures', 'module-cache', 'cjs-counter.js');
+
+const outer = 16;
+const inner = 64;
+
+checkIfCollectableByCounting(() => {
+  for (let i = 0; i < inner; i++) {
+    require(fixture);
+    clearCache(fixture, {
+      parentURL: pathToFileURL(__filename),
+      resolver: 'require',
+    });
+  }
+  return inner;
+}, Module, outer).then(common.mustCall(() => {
+  delete globalThis.__module_cache_cjs_counter;
+}));

--- a/test/parallel/test-module-clear-cache-module-wrap-leak.js
+++ b/test/parallel/test-module-clear-cache-module-wrap-leak.js
@@ -1,0 +1,40 @@
+// Flags: --expose-internals
+// Verifies that ModuleWrap instances created by import() are garbage-
+// collectible after clearCache. This is the strongest
+// guarantee that clearing works end-to-end: V8 itself can reclaim the
+// underlying module.
+'use strict';
+
+const common = require('../common');
+
+const { pathToFileURL } = require('node:url');
+const { clearCache } = require('node:module');
+const { internalBinding } = require('internal/test/binding');
+const { ModuleWrap } = internalBinding('module_wrap');
+const { checkIfCollectableByCounting } = require('../common/gc');
+
+const fixtureURL = new URL(
+  '../fixtures/module-cache/esm-counter.mjs',
+  pathToFileURL(__filename),
+);
+const parentURL = pathToFileURL(__filename).href;
+
+const outer = 8;
+const inner = 4;
+
+const runIteration = common.mustCallAtLeast(async (i) => {
+  for (let j = 0; j < inner; j++) {
+    const url = `${fixtureURL.href}?hmr=${i}-${j}`;
+    await import(url);
+    clearCache(url, {
+      parentURL,
+      resolver: 'import',
+    });
+  }
+  return inner;
+});
+
+checkIfCollectableByCounting(runIteration, ModuleWrap, outer)
+  .then(common.mustCall(() => {
+    delete globalThis.__module_cache_esm_counter;
+  }));

--- a/test/parallel/test-module-clear-cache-options.js
+++ b/test/parallel/test-module-clear-cache-options.js
@@ -1,0 +1,142 @@
+'use strict';
+
+require('../common');
+
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+const { clearCache } = require('node:module');
+
+const fixture = path.join(__dirname, '..', 'fixtures', 'module-cache', 'cjs-counter.js');
+const relativeSpecifier = '../fixtures/module-cache/cjs-counter.js';
+
+require(fixture);
+
+// parentURL must be a valid URL, not a file path.
+assert.throws(() => clearCache(relativeSpecifier, {
+  parentURL: __filename,
+  resolver: 'require',
+}), {
+  code: 'ERR_INVALID_ARG_VALUE',
+});
+
+// Missing parentURL throws.
+assert.throws(() => clearCache(fixture, {
+  resolver: 'require',
+}), {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
+
+// Missing resolver throws.
+assert.throws(() => clearCache(fixture, {
+  parentURL: pathToFileURL(__filename),
+}), {
+  code: 'ERR_INVALID_ARG_VALUE',
+});
+
+// Invalid resolver throws.
+assert.throws(() => clearCache(fixture, {
+  parentURL: pathToFileURL(__filename),
+  resolver: 'invalid',
+}), {
+  code: 'ERR_INVALID_ARG_VALUE',
+});
+
+// Valid call with relative specifier and file URL parentURL.
+clearCache(relativeSpecifier, {
+  parentURL: pathToFileURL(__filename),
+  resolver: 'require',
+});
+assert.strictEqual(require.cache[fixture], undefined);
+
+const first = require(fixture);
+clearCache(fixture, {
+  parentURL: pathToFileURL(__filename),
+  resolver: 'require',
+});
+const second = require(fixture);
+assert.notStrictEqual(first.count, second.count);
+assert.strictEqual(first.count, 2);
+assert.strictEqual(second.count, 3);
+
+// --- Additional validation edge cases ---
+
+// Missing options entirely.
+assert.throws(() => clearCache(fixture), {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
+
+// Options must be an object.
+assert.throws(() => clearCache(fixture, 'bad'), {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
+
+// Specifier must be a string or URL.
+assert.throws(() => clearCache(123, {
+  parentURL: pathToFileURL(__filename),
+  resolver: 'require',
+}), {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
+
+// importAttributes must be an object if provided.
+assert.throws(() => clearCache(fixture, {
+  parentURL: pathToFileURL(__filename),
+  resolver: 'require',
+  importAttributes: 'bad',
+}), {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
+
+// --- No-op scenarios (should not throw) ---
+
+// Clearing a module that was never loaded — no-op.
+const unloaded = path.join(__dirname, '..', 'fixtures', 'module-cache', 'cjs-child.js');
+assert.strictEqual(require.cache[unloaded], undefined);
+clearCache(unloaded, {
+  parentURL: pathToFileURL(__filename),
+  resolver: 'require',
+});
+assert.strictEqual(require.cache[unloaded], undefined);
+
+// Clearing the same module twice — second call is a no-op.
+clearCache(fixture, {
+  parentURL: pathToFileURL(__filename),
+  resolver: 'require',
+});
+clearCache(fixture, {
+  parentURL: pathToFileURL(__filename),
+  resolver: 'require',
+});
+
+// URL object specifier with resolver: 'require' is a no-op.
+// CJS does not interpret file: URLs as paths; hooks would be needed to handle them.
+const third = require(fixture);
+assert.strictEqual(third.count, 4);
+clearCache(pathToFileURL(fixture), {
+  parentURL: pathToFileURL(__filename),
+  resolver: 'require',
+});
+// Cache should still be populated — URL specifiers are not resolved for CJS.
+assert.notStrictEqual(require.cache[fixture], undefined);
+
+// String file: URL specifier with resolver: 'require' is also a no-op.
+clearCache(pathToFileURL(fixture).href, {
+  parentURL: pathToFileURL(__filename),
+  resolver: 'require',
+});
+// Cache should still be populated.
+assert.notStrictEqual(require.cache[fixture], undefined);
+
+// parentURL as string URL (not URL object) — still works when specifier is a path.
+clearCache(fixture, {
+  parentURL: pathToFileURL(__filename).href,
+  resolver: 'require',
+});
+assert.strictEqual(require.cache[fixture], undefined);
+
+// Re-require to bump count for subsequent assertions.
+const fourth = require(fixture);
+assert.strictEqual(fourth.count, 5);
+
+delete globalThis.__module_cache_cjs_counter;

--- a/test/parallel/test-module-clear-cache-options.js
+++ b/test/parallel/test-module-clear-cache-options.js
@@ -109,15 +109,19 @@ clearCache(fixture, {
   resolver: 'require',
 });
 
-// URL object specifier with resolver: 'require' is a no-op.
-// CJS does not interpret file: URLs as paths; hooks would be needed to handle them.
+// URL object specifier with resolver: 'require' is invalid.
+// require() does not accept URL objects.
 const third = require(fixture);
 assert.strictEqual(third.count, 4);
-clearCache(pathToFileURL(fixture), {
-  parentURL: pathToFileURL(__filename),
-  resolver: 'require',
+assert.throws(() => {
+  clearCache(pathToFileURL(fixture), {
+    parentURL: pathToFileURL(__filename),
+    resolver: 'require',
+  });
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
 });
-// Cache should still be populated — URL specifiers are not resolved for CJS.
+// Cache should still be populated.
 assert.notStrictEqual(require.cache[fixture], undefined);
 
 // String file: URL specifier with resolver: 'require' is also a no-op.

--- a/test/parallel/test-module-clear-cache-parent-links.js
+++ b/test/parallel/test-module-clear-cache-parent-links.js
@@ -1,0 +1,42 @@
+// Flags: --expose-internals
+'use strict';
+
+require('../common');
+
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+const { clearCache } = require('node:module');
+const { internalBinding } = require('internal/test/binding');
+
+const {
+  privateSymbols: {
+    module_first_parent_private_symbol,
+    module_last_parent_private_symbol,
+  },
+} = internalBinding('util');
+
+const parentPath = path.join(__dirname, '..', 'fixtures', 'module-cache', 'cjs-parent.js');
+const childPath = path.join(__dirname, '..', 'fixtures', 'module-cache', 'cjs-child.js');
+
+require(parentPath);
+
+const childModule = require.cache[childPath];
+const parentModule = require.cache[parentPath];
+
+assert.strictEqual(childModule[module_first_parent_private_symbol], parentModule);
+assert.strictEqual(childModule[module_last_parent_private_symbol], parentModule);
+
+clearCache(parentPath, {
+  parentURL: pathToFileURL(__filename),
+  resolver: 'require',
+});
+
+assert.strictEqual(childModule[module_first_parent_private_symbol], undefined);
+assert.strictEqual(childModule[module_last_parent_private_symbol], undefined);
+
+clearCache(childPath, {
+  parentURL: pathToFileURL(__filename),
+  resolver: 'require',
+});
+delete globalThis.__module_cache_cjs_child_counter;

--- a/test/parallel/test-module-clear-cache-parent-links.js
+++ b/test/parallel/test-module-clear-cache-parent-links.js
@@ -1,42 +1,28 @@
-// Flags: --expose-internals
 'use strict';
 
-require('../common');
+const common = require('../common');
 
-const assert = require('node:assert');
 const path = require('node:path');
 const { pathToFileURL } = require('node:url');
 const { clearCache } = require('node:module');
-const { internalBinding } = require('internal/test/binding');
+const Module = require('node:module');
+const { checkIfCollectableByCounting } = require('../common/gc');
 
-const {
-  privateSymbols: {
-    module_first_parent_private_symbol,
-    module_last_parent_private_symbol,
-  },
-} = internalBinding('util');
+// require(esm) creates a CJS cache entry that wraps the ES module. After
+// clearCache, that wrapper (and the loaded module) must be collectible.
+const fixture = path.join(__dirname, '..', 'fixtures', 'module-cache', 'esm-counter.mjs');
 
-const parentPath = path.join(__dirname, '..', 'fixtures', 'module-cache', 'cjs-parent.js');
-const childPath = path.join(__dirname, '..', 'fixtures', 'module-cache', 'cjs-child.js');
+const outer = 8;
+const inner = 4;
 
-require(parentPath);
-
-const childModule = require.cache[childPath];
-const parentModule = require.cache[parentPath];
-
-assert.strictEqual(childModule[module_first_parent_private_symbol], parentModule);
-assert.strictEqual(childModule[module_last_parent_private_symbol], parentModule);
-
-clearCache(parentPath, {
-  parentURL: pathToFileURL(__filename),
-  resolver: 'require',
-});
-
-assert.strictEqual(childModule[module_first_parent_private_symbol], undefined);
-assert.strictEqual(childModule[module_last_parent_private_symbol], undefined);
-
-clearCache(childPath, {
-  parentURL: pathToFileURL(__filename),
-  resolver: 'require',
-});
-delete globalThis.__module_cache_cjs_child_counter;
+checkIfCollectableByCounting(() => {
+  for (let i = 0; i < inner; i++) {
+    require(fixture);
+    clearCache(fixture, {
+      parentURL: pathToFileURL(__filename),
+      resolver: 'require',
+    });
+  }
+  delete globalThis.__module_cache_esm_counter;
+  return inner;
+}, Module, outer).then(common.mustCall());

--- a/test/parallel/test-module-clear-cache-pkgjson-exports.js
+++ b/test/parallel/test-module-clear-cache-pkgjson-exports.js
@@ -1,0 +1,54 @@
+// Tests that after updating package.json exports to point to a different file,
+// clearCache causes re-resolution to pick up the new export.
+'use strict';
+
+require('../common');
+const tmpdir = require('../common/tmpdir');
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+const { clearCache, createRequire } = require('node:module');
+
+tmpdir.refresh();
+
+// Create a temporary package with two entry points.
+const pkgDir = path.join(tmpdir.path, 'node_modules', 'test-exports-pkg');
+fs.mkdirSync(pkgDir, { recursive: true });
+
+fs.writeFileSync(path.join(pkgDir, 'entry-a.js'),
+                 'module.exports = "a";\n');
+fs.writeFileSync(path.join(pkgDir, 'entry-b.js'),
+                 'module.exports = "b";\n');
+
+// Initial package.json: exports points to entry-a.js.
+fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({
+  name: 'test-exports-pkg',
+  exports: './entry-a.js',
+}));
+
+// Create a require function rooted in tmpdir so it finds node_modules there.
+const parentFile = path.join(tmpdir.path, 'parent.js');
+fs.writeFileSync(parentFile, '');
+const localRequire = createRequire(parentFile);
+
+// First require — should resolve to entry-a.
+const resultA = localRequire('test-exports-pkg');
+assert.strictEqual(resultA, 'a');
+
+// Update the package.json to point exports to entry-b.js.
+fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({
+  name: 'test-exports-pkg',
+  exports: './entry-b.js',
+}));
+
+// Clear all caches for the package.
+clearCache('test-exports-pkg', {
+  parentURL: pathToFileURL(parentFile),
+  resolver: 'require',
+});
+
+// Second require — should now resolve to entry-b.
+const resultB = localRequire('test-exports-pkg');
+assert.strictEqual(resultB, 'b');

--- a/test/parallel/test-module-clear-cache-source-map-closure.js
+++ b/test/parallel/test-module-clear-cache-source-map-closure.js
@@ -1,0 +1,33 @@
+// Flags: --enable-source-maps
+'use strict';
+
+require('../common');
+
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+const { clearCache } = require('node:module');
+
+const fixture = path.join(
+  __dirname,
+  '..',
+  'fixtures',
+  'source-map',
+  'cjs-closure-source-map.js',
+);
+
+const { crash } = require(fixture);
+
+clearCache(fixture, {
+  parentURL: pathToFileURL(__filename),
+  resolver: 'require',
+});
+
+assert.strictEqual(require.cache[fixture], undefined);
+
+try {
+  crash();
+  assert.fail('Expected crash() to throw');
+} catch (err) {
+  assert.match(err.stack, /cjs-closure-source-map-original\.js/);
+}

--- a/test/parallel/test-module-clear-cache.js
+++ b/test/parallel/test-module-clear-cache.js
@@ -1,0 +1,29 @@
+'use strict';
+
+require('../common');
+
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+const { clearCache } = require('node:module');
+
+const fixture = path.join(__dirname, '..', 'fixtures', 'module-cache', 'cjs-counter.js');
+
+const first = require(fixture);
+const second = require(fixture);
+
+assert.strictEqual(first.count, 1);
+assert.strictEqual(second.count, 1);
+assert.strictEqual(first, second);
+
+clearCache(fixture, {
+  parentURL: pathToFileURL(__filename),
+  resolver: 'require',
+});
+
+assert.strictEqual(require.cache[fixture], undefined);
+
+const third = require(fixture);
+assert.strictEqual(third.count, 2);
+
+delete globalThis.__module_cache_cjs_counter;

--- a/typings/internalBinding/modules.d.ts
+++ b/typings/internalBinding/modules.d.ts
@@ -29,4 +29,5 @@ export interface ModulesBinding {
   enableCompileCache(path?: string): { status: number, message?: string, directory?: string }
   getCompileCacheDir(): string | undefined
   flushCompileCache(keepDeserializedCache?: boolean): void
+  clearPackageJSONCache(path: string): boolean
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the `module.clearCache` work from [nodejs/node#61767](https://github.com/nodejs/node/pull/61767) after rebasing onto current `main` and addressing the remaining review threads.

## Rebase

Rebased `yagiz/node-module-clear-cache` onto `origin/main`. Conflicts were in:

- `lib/internal/modules/esm/translators.js` — kept main's `loadCJSModuleWithModuleLoad` (`translateContext`, hook skip, patched `_load` export mirroring) and re-installed the CJS cache entry when `clearCache` races an in-flight `import()`.
- `lib/internal/modules/helpers.js` — exported both `getRequireStack` (from main) and `getFilePathFromFileURL` (from this change).

The original PR branch `yagiz/node-module-clear-cache` was force-pushed with the same commits so [nodejs/node#61767](https://github.com/nodejs/node/pull/61767) is updated.

## Review comments addressed

Unresolved threads from joyeecheung, jsumners-nr, and related conversation comments:

- **Docs:** `parentURL` and `resolver` are documented as required. Added relative, bare, and absolute-URL examples. Clarified there is no recursive option. Rewrote the memory-retention section so it talks about user-module references (for example static `import`) rather than `ModuleWrap` / V8 internals. Added a CommonJS test-reload example.
- **`resolver: 'require'` + `URL`:** throws `ERR_INVALID_ARG_TYPE`. String specifiers that look like `file:` URLs are still treated as paths, matching `require()`.
- **`kLinkedRequestsSlot`:** cleared after successful `ModuleWrap` instantiation so imported wraps are not pinned after they leave Node.js caches.
- **Tests:** stopped asserting on internal resolve-cache helpers and private parent symbols; those tests now check reload behavior and GC collectability. Hash-map test comments no longer name `hash_to_module_map`.

Recursive cache clearing was not added (see laverdet's comment on that thread).

## Testing

ESLint on the changed JS/test files and `doc/api/module.md` is clean. `lint-md` on `doc/api/module.md` is clean. A full Node.js rebuild is still needed to run the `test/parallel/test-module-clear-cache*` and `test/es-module/test-module-clear-cache*` suites, and to exercise the C++ `kLinkedRequestsSlot` change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a021c7-cd8d-73d3-ac37-565938b468bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a021c7-cd8d-73d3-ac37-565938b468bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

